### PR TITLE
image-hd: set the position of extended partition

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -57,6 +57,7 @@ EXTRA_DIST += \
 	test/flash.md5 \
 	test/hdimage.config \
 	test/hdimage.fdisk \
+	test/hdimage.fdisk-2 \
 	test/iso.config \
 	test/jffs2.config \
 	test/jffs2.md5 \

--- a/test/basic-images.test
+++ b/test/basic-images.test
@@ -191,7 +191,14 @@ test_expect_success "hdimage" "
 	# check partitions; filter output to handle different sfdisk versions
 	sfdisk -d images/test.hdimage 2>/dev/null | grep '^images/' | \
 		sed -e 's/  *//g' -e 's;Id=;type=;' >> hdimage.fdisk &&
-	test_cmp '${testdir}/hdimage.fdisk' hdimage.fdisk
+	test_cmp '${testdir}/hdimage.fdisk' hdimage.fdisk &&
+	check_size images/test.hdimage-2 11534336 &&
+	# check the this identifier
+	fdisk -l images/test.hdimage-2 | grep identifier: > hdimage.fdisk-2 &&
+	# check partitions; filter output to handle different sfdisk versions
+	sfdisk -d images/test.hdimage-2 2>/dev/null | grep '^images/' | \
+		sed -e 's/  *//g' -e 's;Id=;type=;' -e '/start=0,size=0,type=0/d' >> hdimage.fdisk-2 &&
+	test_cmp '${testdir}/hdimage.fdisk-2' hdimage.fdisk-2
 "
 
 exec_test_set_prereq genisoimage

--- a/test/hdimage.config
+++ b/test/hdimage.config
@@ -34,3 +34,41 @@ image test.hdimage {
 		partition-type = 0x83
 	}
 }
+
+image test.hdimage-2 {
+	hdimage {
+		align = 1M
+		disk-signature = 0x12345678
+		extended-partition = 2
+	}
+	partition part1 {
+		image = "part1.img"
+		size = 1M
+		partition-type = 0x83
+	}
+	partition part2 {
+		image = "part2.img"
+		size = 1M
+		partition-type = 0x83
+	}
+	partition part3 {
+		image = "part1.img"
+		size = 1M
+		partition-type = 0x83
+	}
+	partition part4 {
+		image = "part2.img"
+		size = 1M
+		partition-type = 0x83
+	}
+	partition part5 {
+		image = "part1.img"
+		size = 1M
+		partition-type = 0x83
+	}
+	partition part6 {
+		image = "part2.img"
+		size = 1M
+		partition-type = 0x83
+	}
+}

--- a/test/hdimage.fdisk-2
+++ b/test/hdimage.fdisk-2
@@ -1,0 +1,8 @@
+Disk identifier: 0x12345678
+images/test.hdimage-2p1:start=2048,size=2048,type=83
+images/test.hdimage-2p2:start=4096,size=20480,type=f
+images/test.hdimage-2p5:start=6144,size=2048,type=83
+images/test.hdimage-2p6:start=10240,size=2048,type=83
+images/test.hdimage-2p7:start=14336,size=2048,type=83
+images/test.hdimage-2p8:start=18432,size=2048,type=83
+images/test.hdimage-2p9:start=22528,size=2048,type=83


### PR DESCRIPTION
The hdimage property "primary-partitions" limits the number of primary
partitions recorded into the Master Boot Record.

Limiting the number of primary partitions to 2 into the MBR allows to
create Extended Partition Boot Record scheme images. This kind of images
is composed of one primary and one extended partition.

Signed-off-by: Gaël PORTAY <gael.portay@savoirfairelinux.com>