### PR TITLE
vfat, ext2: print error message when size is zero

### DIFF
--- a/image-ext2.c
+++ b/image-ext2.c
@@ -57,6 +57,16 @@ static int ext2_generate(struct image *image)
 	return ret > 2;
 }
 
+static int ext2_setup(struct image *image, cfg_t *cfg)
+{
+	if (!image->size) {
+		image_error(image, "no size given or must not be zero\n");
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
 static cfg_opt_t ext2_opts[] = {
 	CFG_STR("extraargs", "", CFGF_NONE),
 	CFG_STR("features", 0, CFGF_NONE),
@@ -67,6 +77,7 @@ static cfg_opt_t ext2_opts[] = {
 struct image_handler ext2_handler = {
 	.type = "ext2",
 	.generate = ext2_generate,
+	.setup = ext2_setup,
 	.opts = ext2_opts,
 };
 
@@ -80,6 +91,7 @@ static cfg_opt_t ext3_opts[] = {
 struct image_handler ext3_handler = {
 	.type = "ext3",
 	.generate = ext2_generate,
+	.setup = ext2_setup,
 	.opts = ext3_opts,
 };
 
@@ -93,6 +105,7 @@ static cfg_opt_t ext4_opts[] = {
 struct image_handler ext4_handler = {
 	.type = "ext4",
 	.generate = ext2_generate,
+	.setup = ext2_setup,
 	.opts = ext4_opts,
 };
 

--- a/image-vfat.c
+++ b/image-vfat.c
@@ -70,6 +70,16 @@ static int vfat_generate(struct image *image)
 	return ret;
 }
 
+static int vfat_setup(struct image *image, cfg_t *cfg)
+{
+	if (!image->size) {
+		image_error(image, "no size given or must not be zero\n");
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
 static int vfat_parse(struct image *image, cfg_t *cfg)
 {
 	unsigned int i;
@@ -110,6 +120,7 @@ static cfg_opt_t vfat_opts[] = {
 struct image_handler vfat_handler = {
 	.type = "vfat",
 	.generate = vfat_generate,
+	.setup = vfat_setup,
 	.parse = vfat_parse,
 	.opts = vfat_opts,
 };


### PR DESCRIPTION
The `size' property is mandatory and cannot be 0 for vfat and ext file
systems.

Print a message that is more helpful than:

	genext2fs: too few blocks. Note: options have changed, see --help or the man page.
	ext2(test.ext2): failed to generate test.ext2

and

	mkdosfs: unable to discover size of images/test.vfat
	vfat(test.vfat): failed to generate test.vfat

Signed-off-by: Gaël PORTAY <gael.portay@savoirfairelinux.com>