### PR TITLE
util: print suffix error

### DIFF
--- a/util.c
+++ b/util.c
@@ -196,7 +196,7 @@ unsigned long long strtoul_suffix(const char *str, char **endp, int base)
 	case '\0':
 		break;
 	default:
-		error("Invalid size suffix in: '%s'\n", str);
+		error("Invalid size suffix '%s' in '%s'\n", end, str);
 		exit(1);
 	}
 


### PR DESCRIPTION
Print the suffix to get a more precise message when the suffix is
invalid.

For example, it prints the following trace when size is '7.5M':

	Invalid size suffix '.5M' in '7.5M'

Signed-off-by: Gaël PORTAY <gael.portay@savoirfairelinux.com>