### PR TITLE
image-hd: fix offset in case of no offset/partition table

### DIFF
--- a/image-hd.c
+++ b/image-hd.c
@@ -295,7 +295,7 @@ static int hdimage_setup(struct image *image, cfg_t *cfg)
 						part->name);
 				return -EINVAL;
 			}
-		} else if (!part->offset) {
+		} else if (!part->offset && part->in_partition_table) {
 			if (!now && hd->partition_table)
 				now = 512;
 			part->offset = roundup(now, hd->align);


### PR DESCRIPTION
This lead to an accidental offset, ultimatively leading to not bootable
hd images.

Fixes: 5d3fd814bd23 ("image-hd: fix offset validation")
Signed-off-by: Bastian Stender <bst@pengutronix.de>