### PR TITLE
image-hd: fix partition handling

### DIFF
--- a/image-hd.c
+++ b/image-hd.c
@@ -255,7 +255,7 @@ static int hdimage_setup(struct image *image, cfg_t *cfg)
 	}
 	if (!hd->extended_partition && partition_table_entries > 4)
 	        hd->extended_partition = 4;
-	has_extended = partition_table_entries >= hd->extended_partition;
+	has_extended = hd->extended_partition > 0;
 
 	partition_table_entries = 0;
 	list_for_each_entry(part, &image->partitions, list) {


### PR DESCRIPTION
With no extended partition 'hd->extended_partition' is zero. As a result
'has_extended' is set incorrectly.
The extended partition number is now defined explicitly so we can use it to
define 'has_extended'.

Fixes: c17203afa2d6 ("image-hd: set the position of extended partition")
Signed-off-by: Michael Olbrich <m.olbrich@pengutronix.de>