### PR TITLE
pad_file, insert_data: be more verbose on errors

### DIFF
--- a/image-file.c
+++ b/image-file.c
@@ -63,9 +63,10 @@ static int file_setup(struct image *image, cfg_t *cfg)
 
 	ret = stat(f->infile, &s);
 	if (ret) {
+		ret = -errno;
 		image_error(image, "stat(%s) failed: %s\n", f->infile,
 				strerror(errno));
-		return -errno;
+		return ret;
 	}
 	if (!image->size)
 		image->size = s.st_size;

--- a/image-ubi.c
+++ b/image-ubi.c
@@ -40,8 +40,8 @@ static int ubi_generate(struct image *image)
 
 	fini = fopen(tempfile, "w");
 	if (!fini) {
-		image_error(image, "creating temp file failed: %s\n", strerror(errno));
 		ret = -errno;
+		image_error(image, "creating temp file failed: %s\n", strerror(errno));
 		goto err_free;
 	}
 

--- a/util.c
+++ b/util.c
@@ -222,16 +222,16 @@ int pad_file(struct image *image, const char *infile, const char *outfile,
 	if (infile) {
 		f = fopen(infile, "r");
 		if (!f) {
-			image_error(image, "open %s: %s\n", infile, strerror(errno));
 			ret = -errno;
+			image_error(image, "open %s: %s\n", infile, strerror(errno));
 			goto err_out;
 		}
 	}
 
 	outf = fopen(outfile, mode == MODE_OVERWRITE ? "w" : "a");
 	if (!outf) {
-		image_error(image, "open %s: %s\n", outfile, strerror(errno));
 		ret = -errno;
+		image_error(image, "open %s: %s\n", outfile, strerror(errno));
 		goto err_out;
 	}
 
@@ -306,14 +306,14 @@ int insert_data(struct image *image, const char *data, const char *outfile,
 	if (!outf && errno == ENOENT)
 		outf = fopen(outfile, "w");
 	if (!outf) {
-		image_error(image, "open %s: %s\n", outfile, strerror(errno));
 		ret = -errno;
+		image_error(image, "open %s: %s\n", outfile, strerror(errno));
 		goto err_out;
 	}
 	ret = fseek(outf, offset, SEEK_SET);
 	if (ret) {
-		image_error(image, "seek %s: %s\n", outfile, strerror(errno));
 		ret = -errno;
+		image_error(image, "seek %s: %s\n", outfile, strerror(errno));
 		goto err_out;
 	}
 	while (size) {

--- a/util.c
+++ b/util.c
@@ -243,6 +243,7 @@ int pad_file(struct image *image, const char *infile, const char *outfile,
 		if (ret)
 			goto err_out;
 		if ((unsigned long long)s.st_size > size) {
+			image_error(image, "input file '%s' too large\n", outfile);
 			ret = -EINVAL;
 			goto err_out;
 		}
@@ -257,6 +258,7 @@ int pad_file(struct image *image, const char *infile, const char *outfile,
 		w = fwrite(buf, 1, r, outf);
 		if (w < r) {
 			ret = -errno;
+			image_error(image, "write %s: %s\n", outfile, strerror(errno));
 			goto err_out;
 		}
 		size -= r;
@@ -281,6 +283,7 @@ fill:
 		r = fwrite(buf, 1, now, outf);
 		if (r < now) {
 			ret = -errno;
+			image_error(image, "write %s: %s\n", outfile, strerror(errno));
 			goto err_out;
 		}
 		size -= now;
@@ -322,6 +325,7 @@ int insert_data(struct image *image, const char *data, const char *outfile,
 		r = fwrite(data, 1, now, outf);
 		if (r < now) {
 			ret = -errno;
+			image_error(image, "write %s: %s\n", outfile, strerror(errno));
 			goto err_out;
 		}
 		size -= now;


### PR DESCRIPTION
The current behaviour is not very informative:

```
hdimage(hd.img): adding partition 'root' (in MBR) from 'root.ext2' ...
hdimage(hd.img): failed to write image partition 'root'
hdimage(hd.img): failed to generate hd.img
```

Now I have at least a hint why it fails:

```
hdimage(hd.img): adding partition 'root' (in MBR) from 'root.ext2' ...
hdimage(hd.img): write /path/to/hd.img: No space left on device
hdimage(hd.img): failed to write image partition 'root'
hdimage(hd.img): failed to generate hd.img
```

The first commits also fix errno handling in the existing code base.