### PR TITLE
config.c: disable mtools C-H-S adressing check by default

### DIFF
--- a/image-vfat.c
+++ b/image-vfat.c
@@ -48,7 +48,7 @@ static int vfat_generate(struct image *image)
 		while ((next = strchr(next, '/')) != NULL) {
 			*next = '\0';
 			/* ignore the error: mdd fails if the target exists. */
-			systemp(image, "%s -DsS -i %s '::%s'",
+			systemp(image, "MTOOLS_SKIP_CHECK=1 %s -DsS -i %s '::%s'",
 				get_opt("mmd"), imageoutfile(image), path);
 			*next = '/';
 			++next;
@@ -56,7 +56,7 @@ static int vfat_generate(struct image *image)
 
 		image_info(image, "adding file '%s' as '%s' ...\n",
 				child->file, *target ? target : child->file);
-		ret = systemp(image, "%s -bsp -i '%s' '%s' '::%s'",
+		ret = systemp(image, "MTOOLS_SKIP_CHECK=1 %s -bsp -i '%s' '%s' '::%s'",
 				get_opt("mcopy"), imageoutfile(image),
 				file, target);
 		if (ret)
@@ -65,8 +65,8 @@ static int vfat_generate(struct image *image)
 	if (!list_empty(&image->partitions))
 		return 0;
 
-	ret = systemp(image, "%s -bsp -i '%s' '%s'/* ::", get_opt("mcopy"),
-			imageoutfile(image), mountpath(image));
+	ret = systemp(image, "MTOOLS_SKIP_CHECK=1 %s -bsp -i '%s' '%s'/* ::",
+			get_opt("mcopy"), imageoutfile(image), mountpath(image));
 	return ret;
 }
 

--- a/test/basic-images.test
+++ b/test/basic-images.test
@@ -274,8 +274,8 @@ exec_test_set_prereq mkdosfs
 exec_test_set_prereq mcopy
 test_expect_success dd,mkdosfs,mcopy "vfat" "
 	run_genimage vfat.config test.vfat &&
-	check_size images/test.vfat 4194304
-	mdir -/ -f -b -i images/test.vfat / | sed -e 's;^::/;;' -e 's;/$;;' | sort > '${filelist_test}' &&
+	check_size images/test.vfat 4193280
+	MTOOLS_SKIP_CHECK=1 mdir -/ -f -b -i images/test.vfat / | sed -e 's;^::/;;' -e 's;/$;;' | sort > '${filelist_test}' &&
 	check_filelist
 "
 

--- a/test/vfat.config
+++ b/test/vfat.config
@@ -2,5 +2,5 @@ image test.vfat {
 	vfat {
 		extraargs = "-n 'vfat-test'"
 	}
-	size = 4M
+	size = 4095K
 }


### PR DESCRIPTION
Mtools by default refuses to work with filesystems not fitting the legacy
C-H-S adressing, E.G. bigger than 511MB or with "odd" sizes.

mkdosfs writes a BIOS parameter block containing (among others) the number
of sectors per track and heads.  This parameter block is what mtools reads
and validates that total sectors is a multiple of sectors/track times heads.

For small(<512MB) filesystems, mkdosfs uses sectors/track = 32 and heads =
64, allowing filesystems of multiples of 1MB to validate.  For bigger
filesystems it instead uses sectors/track = 63 and heads = 255 to signify
LBA addressing.  63 * 255 * 512 bytes is not a multiple of 1MB, so the
validation in mtools fails for filesystems of multiples of 1MB, E.G:

image test.fat {
  vfat {
    files = { "test.txt" }
  }
  size = 512M
}

Errors out with:

Total number of sectors (10444800) not a multiple of sectors per track (63)!
Add mtools_skip_check=1 to your .mtoolsrc file to skip this test

This legacy check can be disabled by the MTOOLS_SKIP_CHECK environment
variable (or editing the .mtoolsrc as described by the error message), so
pass MTOOLS_SKIP_CHECK=1 by default to mcopy/mmd.

Signed-off-by: Peter Korsgaard <peter@korsgaard.com>