### PR TITLE
hdimage: use random mbr disk signature if not provided

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -189,7 +189,9 @@ Options:
 :extended-partition:	Number of the extended partition. Contains the number of the
 			extended partition between 1 and 4 or 0 for automatic. Defaults
 			to 0.
-:disk-signature:	32 bit integer used as disk signature (offset 440 in the MBR)
+:disk-signature:	32 bit integer used as disk signature (offset 440 in the
+                        MBR). Using a special value ``random`` will result in
+                        using random 32 bit number.
 :gpt:			Boolean. If true, a GPT type partion table is written. If false
 			a DOS type partition table is written. Defaults to false.
 :disk-uuid:		UUID string used as disk id in GPT partitioning. Defaults to a

--- a/image-hd.c
+++ b/image-hd.c
@@ -416,12 +416,13 @@ static int hdimage_setup(struct image *image, cfg_t *cfg)
 	int has_extended, autoresize = 0;
 	unsigned int partition_table_entries = 0;
 	unsigned long long now = 0;
+	const char *disk_signature;
 	struct hdimage *hd = xzalloc(sizeof(*hd));
 
 	hd->align = cfg_getint_suffix(cfg, "align");
 	hd->partition_table = cfg_getbool(cfg, "partition-table");
 	hd->extended_partition = cfg_getint(cfg, "extended-partition");
-	hd->disksig = strtoul(cfg_getstr(cfg, "disk-signature"), NULL, 0);
+	disk_signature = cfg_getstr(cfg, "disk-signature");
 	hd->gpt = cfg_getbool(cfg, "gpt");
 	hd->fill = cfg_getbool(cfg, "fill");
 	hd->disk_uuid = cfg_getstr(cfg, "disk-uuid");
@@ -455,6 +456,11 @@ static int hdimage_setup(struct image *image, cfg_t *cfg)
 	else {
 		hd->disk_uuid = uuid_random();
 	}
+
+	if (!strcmp(disk_signature, "random"))
+		hd->disksig = random();
+	else
+		hd->disksig = strtoul(disk_signature, NULL, 0);
 
 	partition_table_entries = 0;
 	list_for_each_entry(part, &image->partitions, list) {


### PR DESCRIPTION
Disk signature is part of PARTUUID for MBR partitions. PARTUUID can be
used to provide root partition, instead of hardcoding /dev/sd* or
/dev/mmcblk* nodes. The advantage of using PARTUUID is that it doesn't
change across reboots (depending on device drivers probe order).

Up to now 0 value has been used for disk signature if user didn't
provide one. Change behavior to generate unique disk signature in such
case, so we make it less likely to have multiple SD cards with the same
PARTUUIDs connected to a single system, resulting in PARTUUID conflict.

Signed-off-by: Marcin Niestroj <m.niestroj@grinn-global.com>