### PR TITLE
Prefix mountpoints with mp- to avoid conflict with "root"

### DIFF
--- a/genimage.c
+++ b/genimage.c
@@ -392,7 +392,7 @@ static struct mountpoint *add_mountpoint(const char *path)
 	path_sanitized = sanitize_path(path);
 	mp = xzalloc(sizeof(*mp));
 	mp->path = strdup(path);
-	xasprintf(&mp->mountpath, "%s/%s", tmppath(), path_sanitized);
+	xasprintf(&mp->mountpath, "%s/mp-%s", tmppath(), path_sanitized);
 	list_add_tail(&mp->list, &mountpoints);
 	free(path_sanitized);
 


### PR DESCRIPTION
This turned out to be easier than I expected. Bodes well for me hacking on the code in the future!

Closes #67.  Thanks for this extremely useful tool.