### PR TITLE
hdimage: Implement 'gpt-location' option to move GPT table

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -194,6 +194,11 @@ Options:
                         using random 32 bit number.
 :gpt:			Boolean. If true, a GPT type partion table is written. If false
 			a DOS type partition table is written. Defaults to false.
+:gpt-location:		Location of the GPT table. Occasionally useful for moving the GPT
+			table away from where a bootloader is placed due to hardware
+			requirements.  All partitions in the table must begin after this
+			table.  Regardless of this setting, the GPT header will still be
+			placed at 512 bytes (sector 1).  Defaults to 1024 bytes (sector 2).
 :disk-uuid:		UUID string used as disk id in GPT partitioning. Defaults to a
 			random value.
 


### PR DESCRIPTION
This allows the user to specify the location of the GPT table.  This is
useful if a device requires that the bootloader be located in a location
that conflicts with the normal location of the GPT table.

Also, this changes the calculation of the "first usable LBA" to be the
first *listed* partition; this allows the calculation to disregard the
non-listed bootloaders that make this feature useful.  It is up to the
user to ensure that the GPT table is in a location that does not
conflict with any non-listed partition entries.

Comments welcome.