### PR TITLE
make it easier to create empty filesystems

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -76,6 +76,11 @@ Here are all options for images:
 :mountpoint:	mountpoint if image refers to a filesystem image. The
 		default is "/". The content of "${rootpath}${mountpoint}"
 		will be used used fill the filesystem.
+:empty:		If this is set to true, then the specified rootpath and
+		mountpoint are ignored for this image and an empty
+		filesystem is created. This option is only used for
+		writeable filesystem types, such as extX, vfat, ubifs and
+		jffs2. This defaults to false.
 :exec-pre:	Custom command to run before generating the image.
 :exec-post:	Custom command to run after generating the image.
 :flashtype:	refers to a flash section. Optional for non flash like images

--- a/genimage.c
+++ b/genimage.c
@@ -105,6 +105,7 @@ static cfg_opt_t image_common_opts[] = {
 	CFG_STR("name", NULL, CFGF_NONE),
 	CFG_STR("size", NULL, CFGF_NONE),
 	CFG_STR("mountpoint", NULL, CFGF_NONE),
+	CFG_BOOL("empty", cfg_false, CFGF_NONE),
 	CFG_STR("exec-pre", NULL, CFGF_NONE),
 	CFG_STR("exec-post", NULL, CFGF_NONE),
 	CFG_STR("flashtype", NULL, CFGF_NONE),
@@ -672,6 +673,7 @@ int main(int argc, char *argv[])
 		image->size = cfg_getint_suffix_percent(imagesec, "size",
 				&image->size_is_percent);
 		image->mountpoint = cfg_getstr(imagesec, "mountpoint");
+		image->empty = cfg_getbool(imagesec, "empty");
 		image->exec_pre = cfg_getstr(imagesec, "exec-pre");
 		image->exec_post = cfg_getstr(imagesec, "exec-post");
 		if (image->file[0] == '/')

--- a/genimage.h
+++ b/genimage.h
@@ -53,6 +53,7 @@ struct image {
 	unsigned long long size;
 	cfg_bool_t size_is_percent;
 	const char *mountpoint;
+	cfg_bool_t empty;
 	const char *exec_pre;
 	const char *exec_post;
 	unsigned char partition_type;

--- a/image-ext2.c
+++ b/image-ext2.c
@@ -39,10 +39,12 @@ static int ext2_generate_genext2fs(struct image *image)
 	const char *extraargs = cfg_getstr(image->imagesec, "extraargs");
 	const char *label = cfg_getstr(image->imagesec, "label");
 
-	ret = systemp(image, "%s -d '%s' --size-in-blocks=%lld -i 16384 '%s' %s",
+	ret = systemp(image, "%s %s%s%s --size-in-blocks=%lld -i 16384 '%s' %s",
 			get_opt("genext2fs"),
-			mountpath(image), image->size / 1024, imageoutfile(image),
-			extraargs);
+			image->empty ? "" : "-d '",
+			image->empty ? "" : mountpath(image),
+			image->empty ? "" : "'",
+			image->size / 1024, imageoutfile(image), extraargs);
 
 	if (ret)
 		return ret;
@@ -76,11 +78,13 @@ static int ext2_generate_mke2fs(struct image *image)
 	if (is_block_device(imageoutfile(image)))
 		pad_file(image, NULL, 2048, 0x0, MODE_OVERWRITE);
 
-	return systemp(image, "%s%s -t %s%s -E 'root_owner=%s,%s'%s -d '%s' %s %s%s '%s' %lld",
+	return systemp(image, "%s%s -t %s%s -E 'root_owner=%s,%s'%s %s%s%s %s %s%s '%s' %lld",
 			ext->conf_env, get_opt("mke2fs"), image->handler->type,
 			ext->usage_type_args, root_owner, options, ext->size_features,
-			mountpath(image), extraargs,
-			label ? "-L " : "", label ? label : "",
+			image->empty ? "" : "-d '",
+			image->empty ? "" : mountpath(image),
+			image->empty ? "" : "'",
+			extraargs, label ? "-L " : "", label ? label : "",
 			imageoutfile(image), image->size / 1024);
 }
 

--- a/image-jffs2.c
+++ b/image-jffs2.c
@@ -29,10 +29,13 @@ static int jffs2_generate(struct image *image)
 
 	extraargs = cfg_getstr(image->imagesec, "extraargs");
 
-	ret = systemp(image, "%s --eraseblock=%d -d '%s' -o '%s' %s",
+	ret = systemp(image, "%s --eraseblock=%d %s%s%s -o '%s' %s",
 			get_opt("mkfsjffs2"),
-			image->flash_type->pebsize, mountpath(image), imageoutfile(image),
-			extraargs);
+			image->flash_type->pebsize,
+			image->empty ? "" : "-d '",
+			image->empty ? "" : mountpath(image),
+			image->empty ? "" : "'",
+			imageoutfile(image), extraargs);
 
 	return ret;
 }

--- a/image-ubifs.c
+++ b/image-ubifs.c
@@ -34,9 +34,11 @@ static int ubifs_generate(struct image *image)
 	else
 		max_leb_cnt = image->size / image->flash_type->lebsize;
 
-	ret = systemp(image, "%s -d  '%s' -e %d -m %d -c %d -o '%s' %s",
+	ret = systemp(image, "%s %s%s%s -e %d -m %d -c %d -o '%s' %s",
 			get_opt("mkfsubifs"),
-			mountpath(image),
+			image->empty ? "" : "-d '",
+			image->empty ? "" : mountpath(image),
+			image->empty ? "" : "'",
 			image->flash_type->lebsize,
 			image->flash_type->minimum_io_unit_size,
 			max_leb_cnt,

--- a/image-vfat.c
+++ b/image-vfat.c
@@ -65,8 +65,9 @@ static int vfat_generate(struct image *image)
 	if (!list_empty(&image->partitions))
 		return 0;
 
-	ret = systemp(image, "MTOOLS_SKIP_CHECK=1 %s -bsp -i '%s' '%s'/* ::",
-			get_opt("mcopy"), imageoutfile(image), mountpath(image));
+	if (!image->empty)
+		ret = systemp(image, "MTOOLS_SKIP_CHECK=1 %s -bsp -i '%s' '%s'/* ::",
+				get_opt("mcopy"), imageoutfile(image), mountpath(image));
 	return ret;
 }
 

--- a/util.c
+++ b/util.c
@@ -657,5 +657,7 @@ static unsigned long long dir_size(struct image *image, int dirfd,
 
 unsigned long long image_dir_size(struct image *image)
 {
+	if (image->empty)
+		return 0;
 	return dir_size(image, AT_FDCWD, mountpath(image), 4096);
 }


### PR DESCRIPTION
This is useful when creating multiple images with on config and some of
them should be empty. Also, vfat filesystems cannot be empty right now, so
this makes it possible.

Signed-off-by: Michael Olbrich <m.olbrich@pengutronix.de>