### PR TITLE
image-ubifs: validate lebsize

### DIFF
--- a/image-ubifs.c
+++ b/image-ubifs.c
@@ -54,6 +54,11 @@ static int ubifs_setup(struct image *image, cfg_t *cfg)
 		image_error(image, "no flash type given\n");
 		return -EINVAL;
 	}
+	if (image->flash_type->lebsize <= 0) {
+		image_error(image, "invalid lebsize (%d) in %s\n",
+			image->flash_type->lebsize, image->flash_type->name);
+		return -EINVAL;
+	}
 
 	return 0;
 }


### PR DESCRIPTION
Otherwise genimage will crash if lebsize is zero.

Fixes #68.

Signed-off-by: Michael Olbrich <m.olbrich@pengutronix.de>