### PR TITLE
Makefile: add README.rst to release tarball

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -3,6 +3,7 @@ AM_MAKEFLAGS = --no-print-directory
 endif
 
 EXTRA_DIST = \
+	README.rst \
 	test.config \
 	flash.conf
 


### PR DESCRIPTION
Somehow this file didn't make it into the released tarballs, resulting in a serious lack of documentation.