### PR TITLE
util: define AT_NO_AUTOMOUNT if needed

### DIFF
--- a/util.c
+++ b/util.c
@@ -33,6 +33,10 @@
 
 #include "genimage.h"
 
+#ifndef AT_NO_AUTOMOUNT
+#define AT_NO_AUTOMOUNT 0x800
+#endif
+
 static int loglevel(void)
 {
 	static int level = -1;


### PR DESCRIPTION
With old kernel headers, AT_NO_AUTOMOUNT flag is not defined.

Fixes #91

Signed-off-by: Pierre-Jean Texier <pjtexier@koncepto.io>