### PR TITLE
hdimage: Implement 'gpt-no-backup' option to omit backup GPT table

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -215,6 +215,8 @@ Options:
 			requirements.  All partitions in the table must begin after this
 			table.  Regardless of this setting, the GPT header will still be
 			placed at 512 bytes (sector 1).  Defaults to 1024 bytes (sector 2).
+:gpt-no-backup:         Boolean. If true, then the backup partition table at the end of
+                        the image is not written.
 :disk-uuid:		UUID string used as disk id in GPT partitioning. Defaults to a
 			random value.
 


### PR DESCRIPTION
This allows users to create smaller images.
Although this is not the best option for production images,
there is still the case of creating one-time images, which can
be used during development, QA, production, etc.

Signed-off-by: Christoph Muellner <christoph.muellner@theobroma-systems.com>