### PR TITLE
Add support for Hybrid MBR partitions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -101,7 +101,10 @@ Partition options:
 :size:			The size of this partition in bytes. If the size and
 			autoresize are both not set then the size of the partition
 			image is used.
-:partition-type:	Used by dos partition tables to specify the partition type.
+:partition-type:	Used by dos partition tables to specify the partition type. Using
+			this option with a GPT partition table will create a hybrid MBR partition
+			table with a maximum of 3 partition entries(this limit does not effect the
+			maximum number of GPT partition entries in the same image).
 :image:			The image file this partition shall be filled with
 :autoresize:		Boolean specifying that the partition should be resized
 			automatically. For UBI volumes this means that the

--- a/image-hd.c
+++ b/image-hd.c
@@ -95,14 +95,18 @@ static void hdimage_setup_chs(unsigned int lba, unsigned char *chs)
 	chs[2] = (c & 0xff);
 }
 
-static int hdimage_insert_mbr(struct image *image, struct list_head *partitions)
+static int hdimage_insert_mbr(struct image *image, struct list_head *partitions, int hybrid)
 {
 	struct hdimage *hd = image->handler_priv;
 	char mbr[6+4*sizeof(struct mbr_partition_entry)+2], *part_table;
 	struct partition *part;
 	int ret, i = 0;
 
-	image_info(image, "writing MBR\n");
+	if (hybrid) {
+		image_info(image, "writing hybrid MBR\n");
+	} else {
+		image_info(image, "writing MBR\n");
+	}
 
 	memset(mbr, 0, sizeof(mbr));
 	memcpy(mbr, &hd->disksig, sizeof(hd->disksig));
@@ -112,6 +116,12 @@ static int hdimage_insert_mbr(struct image *image, struct list_head *partitions)
 		struct mbr_partition_entry *entry;
 
 		if (!part->in_partition_table)
+			continue;
+
+		if (hybrid && !part->partition_type)
+			continue;
+
+		if (hybrid && part->extended)
 			continue;
 
 		entry = (struct mbr_partition_entry *)(part_table + i *
@@ -143,13 +153,35 @@ static int hdimage_insert_mbr(struct image *image, struct list_head *partitions)
 			break;
 		i++;
 	}
+
+	if (hybrid) {
+		struct mbr_partition_entry *entry;
+
+		entry = (struct mbr_partition_entry *)(part_table + i *
+			sizeof(struct mbr_partition_entry));
+
+		entry->boot = 0x00;
+
+		entry->partition_type = 0xee;
+		entry->relative_sectors = 1;
+		entry->total_sectors = hd->gpt_location / 512 + GPT_SECTORS - 2;
+
+		hdimage_setup_chs(entry->relative_sectors, entry->first_chs);
+		hdimage_setup_chs(entry->relative_sectors +
+		entry->total_sectors - 1, entry->last_chs);
+	}
+
 	part_table += 4 * sizeof(struct mbr_partition_entry);
 	part_table[0] = 0x55;
 	part_table[1] = 0xaa;
 
 	ret = insert_data(image, mbr, imageoutfile(image), sizeof(mbr), 440);
 	if (ret) {
-		image_error(image, "failed to write MBR\n");
+		if (hybrid) {
+			image_error(image, "failed to write hybrid MBR\n");
+		} else {
+			image_error(image, "failed to write MBR\n");
+		}
 		return ret;
 	}
 
@@ -233,7 +265,7 @@ static int hdimage_insert_protective_mbr(struct image *image)
 	mbr.in_partition_table = 1;
 	mbr.partition_type = 0xee;
 	list_add_tail(&mbr.list, &mbr_list);
-	ret = hdimage_insert_mbr(image, &mbr_list);
+	ret = hdimage_insert_mbr(image, &mbr_list, 0);
 	if (ret) {
 		image_error(image,"failed to write protective MBR\n");
 		return ret;
@@ -250,7 +282,7 @@ static int hdimage_insert_gpt(struct image *image, struct list_head *partitions)
 	struct gpt_partition_entry table[GPT_ENTRIES];
 	struct partition *part;
 	unsigned i, j;
-	int ret;
+	int hybrid, ret;
 
 	image_info(image, "writing GPT\n");
 
@@ -266,6 +298,7 @@ static int hdimage_insert_gpt(struct image *image, struct list_head *partitions)
 	header.number_entries = htole32(GPT_ENTRIES);
 	header.entry_size = htole32(sizeof(struct gpt_partition_entry));
 
+	hybrid = 0;
 	i = 0;
 	memset(&table, 0, sizeof(table));
 	list_for_each_entry(part, partitions, list) {
@@ -282,8 +315,19 @@ static int hdimage_insert_gpt(struct image *image, struct list_head *partitions)
 		table[i].flags = part->bootable ? GPT_PE_FLAG_BOOTABLE : 0;
 		for (j = 0; j < strlen(part->name) && j < 36; j++)
 			table[i].name[j] = htole16(part->name[j]);
+
+		if (part->partition_type)
+			hybrid++;
+
 		i++;
 	}
+
+	if (hybrid > 3) {
+		image_error(image, "hybrid MBR partitions (%i) exceeds maximum of 3\n",
+			    hybrid);
+		return -EINVAL;
+	}
+
 	header.table_crc = htole32(crc32(table, sizeof(table)));
 
 	header.header_crc = htole32(crc32(&header, sizeof(header)));
@@ -323,7 +367,11 @@ static int hdimage_insert_gpt(struct image *image, struct list_head *partitions)
 		return ret;
 	}
 
-	ret = hdimage_insert_protective_mbr(image);
+	if (hybrid) {
+		ret = hdimage_insert_mbr(image, partitions, hybrid);
+	} else {
+		ret = hdimage_insert_protective_mbr(image);
+	}
 	if (ret) {
 		return ret;
 	}
@@ -397,7 +445,7 @@ static int hdimage_generate(struct image *image)
 				return ret;
 		}
 		else {
-			ret = hdimage_insert_mbr(image, &image->partitions);
+			ret = hdimage_insert_mbr(image, &image->partitions, 0);
 			if (ret)
 				return ret;
 		}


### PR DESCRIPTION
In order to boot a raspberry pi using GPT one must use a Hybrid MBR partition scheme since the firmware looks for the first available MBR fat32 partition.
Example config:
```
image boot.vfat {
  vfat {
    files = {
      "bcm2710-rpi-3-b.dtb",
      "bcm2710-rpi-3-b-plus.dtb",
      "bcm2837-rpi-3-b.dtb",
      "rpi-firmware/bootcode.bin",
      "rpi-firmware/cmdline.txt",
      "rpi-firmware/config.txt",
      "rpi-firmware/fixup.dat",
      "rpi-firmware/start.elf",
      "rpi-firmware/overlays",
      "Image"
    }
  }
  size = 32M
}

image sdcard.img {
  hdimage {
    gpt = "true"
  }

  partition boot {
    partition-type = 0xC
    partition-type-uuid = c12a7328-f81f-11d2-ba4b-00a0c93ec93b
    bootable = "true"
    image = "boot.vfat"
  }

  partition rootfs {
    partition-uuid = c0932a41-44cf-463b-8152-d43188553ed4
    partition-type-uuid = b921b045-1df0-41c3-af44-4c6f280d3fae
    image = "rootfs.ext4"
  }
}
```