### PR TITLE
image-hd: Add GPT attributes for hiding partitions on Windows

### DIFF
--- a/genimage.c
+++ b/genimage.c
@@ -93,6 +93,8 @@ static cfg_opt_t partition_opts[] = {
 	CFG_INT("partition-type", 0, CFGF_NONE),
 	CFG_BOOL("bootable", cfg_false, CFGF_NONE),
 	CFG_BOOL("read-only", cfg_false, CFGF_NONE),
+	CFG_BOOL("hidden", cfg_false, CFGF_NONE),
+	CFG_BOOL("no-automount", cfg_false, CFGF_NONE),
 	CFG_STR("image", NULL, CFGF_NONE),
 	CFG_BOOL("autoresize", 0, CFGF_NONE),
 	CFG_BOOL("in-partition-table", cfg_true, CFGF_NONE),
@@ -313,6 +315,8 @@ static int parse_partitions(struct image *image, cfg_t *imagesec)
 		part->partition_type = cfg_getint(partsec, "partition-type");
 		part->bootable = cfg_getbool(partsec, "bootable");
 		part->read_only = cfg_getbool(partsec, "read-only");
+		part->hidden = cfg_getbool(partsec, "hidden");
+		part->no_automount = cfg_getbool(partsec, "no-automount");
 		part->image = cfg_getstr(partsec, "image");
 		part->autoresize = cfg_getbool(partsec, "autoresize");
 		part->in_partition_table = cfg_getbool(partsec, "in-partition-table");

--- a/genimage.h
+++ b/genimage.h
@@ -38,6 +38,8 @@ struct partition {
 	cfg_bool_t bootable;
 	cfg_bool_t extended;
 	cfg_bool_t read_only;
+	cfg_bool_t hidden;
+	cfg_bool_t no_automount;
 	const char *image;
 	struct list_head list;
 	int autoresize;

--- a/image-hd.c
+++ b/image-hd.c
@@ -80,7 +80,10 @@ struct gpt_partition_entry {
 #define GPT_SECTORS		(1 + GPT_ENTRIES * sizeof(struct gpt_partition_entry) / 512)
 #define GPT_REVISION_1_0	0x00010000
 
-#define GPT_PE_FLAG_BOOTABLE	(1 << 2)
+#define GPT_PE_FLAG_BOOTABLE	(1ULL << 2)
+#define GPT_PE_FLAG_READ_ONLY	(1ULL << 60)
+#define GPT_PE_FLAG_HIDDEN	(1ULL << 62)
+#define GPT_PE_FLAG_NO_AUTO	(1ULL << 63)
 
 static void hdimage_setup_chs(unsigned int lba, unsigned char *chs)
 {
@@ -279,7 +282,11 @@ static int hdimage_insert_gpt(struct image *image, struct list_head *partitions)
 		uuid_parse(part->partition_uuid, table[i].uuid);
 		table[i].first_lba = htole64(part->offset/512);
 		table[i].last_lba = htole64((part->offset + part->size)/512 - 1);
-		table[i].flags = part->bootable ? GPT_PE_FLAG_BOOTABLE : 0;
+		table[i].flags =
+			(part->bootable ? GPT_PE_FLAG_BOOTABLE : 0) |
+			(part->read_only ? GPT_PE_FLAG_READ_ONLY : 0) |
+			(part->hidden ? GPT_PE_FLAG_HIDDEN : 0) |
+			(part->no_automount ? GPT_PE_FLAG_NO_AUTO : 0);
 		for (j = 0; j < strlen(part->name) && j < 36; j++)
 			table[i].name[j] = htole16(part->name[j]);
 		i++;


### PR DESCRIPTION
This allows users to instruct Windows 10 to ignore certain partitions to
various extent.

I am creating a backup tool based on Linux and I would like to hide the partition containing the Linux system from Windows users so that they don't get confused.