### PR TITLE
image-hd: handle gpt-location when setting/checking the position of t…

### DIFF
--- a/image-hd.c
+++ b/image-hd.c
@@ -550,7 +550,7 @@ static int hdimage_setup(struct image *image, cfg_t *cfg)
 			if (!now && hd->partition_table) {
 				now = 512;
 				if (hd->gpt)
-					now += GPT_SECTORS * 512;
+					now = hd->gpt_location + (GPT_SECTORS - 1) * 512;
 			}
 			part->offset = roundup(now, hd->align);
 		}


### PR DESCRIPTION
…he first partition

If gpt-location is set then the gpt entries are not placed directly behind
the gpt header. Take this into account when calculating the first emtpy
sector available for partitions.

Signed-off-by: Michael Olbrich <m.olbrich@pengutronix.de>