### PR TITLE
image-flash: Abort if size of image exceeds partition size

### DIFF
--- a/image-flash.c
+++ b/image-flash.c
@@ -120,6 +120,19 @@ static int flash_setup(struct image *image, cfg_t *cfg)
 		} else {
 			part->offset = partsize;
 		}
+		if (part->image) {
+			struct image *child = image_get(part->image);
+			if (!child) {
+				image_error(image, "could not find %s\n",
+						part->image);
+				return -EINVAL;
+			}
+			if (child->size > part->size) {
+				image_error(image, "part %s size (%lld) too small for %s (%lld)\n",
+						part->name, part->size, child->file, child->size);
+				return -EINVAL;
+			}
+		}
 
 		partsize = part->offset + part->size;
 	}


### PR DESCRIPTION
Add partition size check similar to the one in hdimage_setup.
Ensures that images do not exceed partition size

I've been bitten by this issue today, resulting in half a u-boot SPL written to a SPI nor flash image and an hour of debugging.