### PR TITLE
image-flash: Pad empty flash partitions to size

### DIFF
--- a/image-flash.c
+++ b/image-flash.c
@@ -50,15 +50,12 @@ static int flash_generate(struct image *image)
 		}
 		mode = MODE_APPEND;
 
-		if (!part->image)
-			continue;
-
-		child = image_get(part->image);
-		if (!child) {
-			image_error(image, "could not find %s\n", part->name);
-			return -EINVAL;
+		if (part->image) {
+			child = image_get(part->image);
+			infile = imageoutfile(child);
+		} else {
+			infile = NULL;
 		}
-		infile = imageoutfile(child);
 
 		ret = pad_file(image, infile, part->size, 0xFF, mode);
 		if (ret) {


### PR DESCRIPTION
According to the documentation a flash image is
> the partition contents padded to the partition sizes concatenated together

Currently empty partitions are not padded to size, resulting in overall
size not equal to the sum of all partition sizes if the last partition
is empty.