### PR TITLE
image-flash: fix regression with empty partitions

### DIFF
--- a/image-flash.c
+++ b/image-flash.c
@@ -53,11 +53,11 @@ static int flash_generate(struct image *image)
 		if (part->image) {
 			child = image_get(part->image);
 			infile = imageoutfile(child);
+			ret = pad_file(image, infile, part->size, 0xFF, mode);
 		} else {
-			infile = NULL;
+			ret = pad_file(image, NULL, part->offset + part->size, 0xFF, mode);
 		}
 
-		ret = pad_file(image, infile, part->size, 0xFF, mode);
 		if (ret) {
 			image_error(image, "failed to write image partition '%s'\n",
 					part->name);


### PR DESCRIPTION
adf18f077010 ("image-flash: Pad empty flash partitions to size") causes
a regression in image-flash.c
Due to a difference in handling of the `size` argument by `pad_file`
depending on `infile == NULL` adf18f077010 is incorrect.
This patch changes the code to call `pad_file` differently if
`infile == NULL`

Fixes: adf18f077010 ("image-flash: Pad empty flash partitions to size")
Signed-off-by: Tobias Schramm <t.schramm@manjaro.org>