### PR TITLE
util: pad_file: always use the full image size for the size argument

### DIFF
--- a/image-flash.c
+++ b/image-flash.c
@@ -57,7 +57,7 @@ static int flash_generate(struct image *image)
 			infile = NULL;
 		}
 
-		ret = pad_file(image, infile, part->size, 0xFF, mode);
+		ret = pad_file(image, infile, part->offset + part->size, 0xFF, mode);
 		if (ret) {
 			image_error(image, "failed to write image partition '%s'\n",
 					part->name);

--- a/image-hd.c
+++ b/image-hd.c
@@ -428,7 +428,7 @@ static int hdimage_generate(struct image *image)
 		child = image_get(part->image);
 		infile = imageoutfile(child);
 
-		ret = pad_file(image, infile, child->size, 0x0, MODE_APPEND);
+		ret = pad_file(image, infile, part->offset + child->size, 0x0, MODE_APPEND);
 
 		if (ret) {
 			image_error(image, "failed to write image partition '%s'\n",

--- a/util.c
+++ b/util.c
@@ -462,15 +462,14 @@ int pad_file(struct image *image, const char *infile,
 
 	buf = xzalloc(4096);
 
-	if (!infile) {
-		if ((unsigned long long)s.st_size > size) {
-			image_error(image, "output file '%s' too large\n", outfile);
-			ret = -EINVAL;
-			goto err_out;
-		}
-		size = size - s.st_size;
-		goto fill;
+	if ((unsigned long long)s.st_size > size) {
+		image_error(image, "output file '%s' too large\n", outfile);
+		ret = -EINVAL;
+		goto err_out;
 	}
+	size = size - s.st_size;
+	if (!infile)
+		goto fill;
 
 	if ((s.st_mode & S_IFMT) == S_IFREG) {
 		ret = map_file_extents(image, infile, f, size, &extents, &extent_count);


### PR DESCRIPTION
Before this, the interpretation of the 'size' argument depended on the
'infile'. If no 'infile' was given, then 'size' was the final size of the
total image.
If an 'infile' was given, then 'size' was the number of bytes to add to the
images.

This is confusing, so change it to always mean the full size the image is
supposed to be once pad_file() is done.

Fixes: adf18f077010 ("image-flash: Pad empty flash partitions to size")
Signed-off-by: Michael Olbrich <m.olbrich@pengutronix.de>