### PR TITLE
util: fix segfault in map_file_extents for effectively zero size files

### DIFF
--- a/util.c
+++ b/util.c
@@ -376,7 +376,7 @@ static int map_file_extents(struct image *image, const char *filename, int f,
 	free(fiemap);
 
 	/* The last extent may extend beyond the end of file, limit it to the actual end */
-	if ((*extents)[i-1].end > size)
+	if (fiemap->fm_mapped_extents && (*extents)[i-1].end > size)
 		(*extents)[i-1].end = size;
 
 	return 0;


### PR DESCRIPTION
Previous to this commit calling `map_file_extents` on an effectively
empty file (either true zero size or an empty sparse file) caused
genimage to segfault.
This is a consequence of FS_IOC_FIEMAP returning 0 mapped extents for
effectively empty files. `map_file_extents` relies on
`number of mapped extent`s > 0 wihtout ever checking it, resulting in
an integer underflow and subsequent segfault due to an out of bounds
memory access.

This commit fixes the issue by checking the number of mapped extents
is not 0 before trying to access the last extent.

Signed-off-by: Tobias Schramm <t.schramm@manjaro.org>