### PR TITLE
image-rauc: allow optional keyring verification

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -285,6 +285,8 @@ Options:
 			RAUC
 :cert:			Path to the certificate file or PKCS#11 URI. Passed to the ``--cert``
 			option of RAUC
+:keyring:		Optional path to the keyring file. Passed to the ``--keyring``
+			option of RAUC
 :manifest:		content of the manifest file
 
 tar

--- a/test/rauc.config
+++ b/test/rauc.config
@@ -13,6 +13,7 @@ image test.raucb {
 			"
 		cert = "rauc-openssl-ca/rauc.cert.pem"
 		key = "rauc-openssl-ca/rauc.key.pem"
+		keyring = "rauc-openssl-ca/ca.cert.pem"
 	}
 }
 image test2.raucb {


### PR DESCRIPTION
A keyring can be specified in genimage's config similar to "cert" and "key". The keyring is passed to the "rauc bundle" command which makes sure the signed bundle can be verified against that keyring.

This is especially helpful for use cases that exceed a single key pair with self-signed certificate, such as a PKI or a keyring consisting of multiple certificates.