### PR TITLE
genimage: initialize return value

### DIFF
--- a/genimage.c
+++ b/genimage.c
@@ -147,7 +147,7 @@ struct image *image_get(const char *filename)
  */
 static int image_setup(struct image *image)
 {
-	int ret;
+	int ret = 0;
 	struct partition *part;
 
 	if (image->done < 0)


### PR DESCRIPTION
The "ret" variable in image_setup is not initialized when an image does
not contain any partitions and the image handler does not provide a
setup function. This can cause image_setup to error out erroneously.

These conditions are fulfilled by the cpio test case, but this bug only
becomes visible when the stack content aligns accordingly.

Initialize ret to 0, as image_setup can be considered successful in this
case.

Signed-off-by: Florian Larysch <fl@n621.de>