### PR TITLE
util: add fiemap fallback for errno ENOTTY

### DIFF
--- a/util.c
+++ b/util.c
@@ -387,7 +387,7 @@ err_out:
 	free(fiemap);
 
 	/* If failure is due to no filesystem support, return a single extent */
-	if (ret == -EOPNOTSUPP)
+	if (ret == -EOPNOTSUPP || ret == -ENOTTY)
 		return whole_file_exent(size, extents, extent_count);
 
 	image_error(image, "fiemap %s: %d %s\n", filename, errno, strerror(errno));


### PR DESCRIPTION
Using genimage (for buildroot) on Ubuntu-20.04.1 on WSL fails
with (see [1] for details):

  ERROR: hdimage(sdcard.img): fiemap .../buildroot-2020.08-rc1/images/boot.vfat: 25 Inappropriate ioctl for device

This is because the fiemap ioctl sets errno to ENOTTY instead of the
expected EOPNOTSUPP.

[1] https://bugs.busybox.net/show_bug.cgi?id=13146

Signed-off-by: Peter Seiderer <ps.report@gmx.net>