### PR TITLE
Make sparse clean

### DIFF
--- a/config.c
+++ b/config.c
@@ -194,7 +194,7 @@ int set_config_opts(int argc, char *argv[], cfg_t *cfg)
 	struct config *c;
 	cfg_t *cfgsec = NULL;
 	int num_opts = 0, n, i;
-	static struct option *long_options = 0;
+	static struct option *long_options = NULL;
 	int ret = 0;
 
 	if (cfg)

--- a/image-ext2.c
+++ b/image-ext2.c
@@ -205,12 +205,12 @@ static cfg_opt_t ext_opts[] = {
 	CFG_STR("root-owner", "0:0", CFGF_NONE),
 	CFG_STR("extraargs", "", CFGF_NONE),
 	CFG_STR("features", NULL, CFGF_NONE),
-	CFG_STR("label", 0, CFGF_NONE),
+	CFG_STR("label", NULL, CFGF_NONE),
 	CFG_STR("fs-timestamp", NULL, CFGF_NONE),
 	CFG_BOOL("use-mke2fs", cfg_false, CFGF_NONE),
 	CFG_STR("usage-type", NULL, CFGF_NONE),
-	CFG_STR("mke2fs-conf", 0, CFGF_NONE),
-	CFG_STR("mke2fs_conf", 0, CFGF_NONE),
+	CFG_STR("mke2fs-conf", NULL, CFGF_NONE),
+	CFG_STR("mke2fs_conf", NULL, CFGF_NONE),
 	CFG_END()
 };
 

--- a/image-hd.c
+++ b/image-hd.c
@@ -660,7 +660,7 @@ static int hdimage_setup(struct image *image, cfg_t *cfg)
 	return 0;
 }
 
-cfg_opt_t hdimage_opts[] = {
+static cfg_opt_t hdimage_opts[] = {
 	CFG_STR("align", "512", CFGF_NONE),
 	CFG_STR("disk-signature", "", CFGF_NONE),
 	CFG_STR("disk-uuid", NULL, CFGF_NONE),

--- a/image-iso.c
+++ b/image-iso.c
@@ -49,7 +49,7 @@ static int iso_generate(struct image *image)
 }
 
 static cfg_opt_t iso_opts[] = {
-	CFG_STR("boot-image", 0, CFGF_NONE),
+	CFG_STR("boot-image", NULL, CFGF_NONE),
 	CFG_STR("bootargs", "-no-emul-boot -boot-load-size 4 -boot-info-table -c boot.cat -hide boot.cat", CFGF_NONE),
 	CFG_STR("extraargs", "", CFGF_NONE),
 	CFG_STR("input-charset", "default", CFGF_NONE),

--- a/image-rauc.c
+++ b/image-rauc.c
@@ -188,7 +188,7 @@ static cfg_opt_t file_opts[] = {
 
 static cfg_opt_t rauc_opts[] = {
 	CFG_STR("extraargs", "", CFGF_NONE),
-	CFG_STR_LIST("files", 0, CFGF_NONE),
+	CFG_STR_LIST("files", NULL, CFGF_NONE),
 	CFG_SEC("file", file_opts, CFGF_MULTI | CFGF_TITLE),
 	CFG_STR("key", NULL, CFGF_NONE),
 	CFG_STR("cert", NULL, CFGF_NONE),

--- a/image-vfat.c
+++ b/image-vfat.c
@@ -127,7 +127,7 @@ static cfg_opt_t file_opts[] = {
 static cfg_opt_t vfat_opts[] = {
 	CFG_STR("extraargs", "", CFGF_NONE),
 	CFG_STR("label", "", CFGF_NONE),
-	CFG_STR_LIST("files", 0, CFGF_NONE),
+	CFG_STR_LIST("files", NULL, CFGF_NONE),
 	CFG_SEC("file", file_opts, CFGF_MULTI | CFGF_TITLE),
 	CFG_END()
 };


### PR DESCRIPTION
This fixes the following warnings when compiling with CC=cgcc:

	config.c:197:46: warning: Using plain integer as NULL pointer
	image-ext2.c:208:9: warning: Using plain integer as NULL pointer
	image-ext2.c:212:9: warning: Using plain integer as NULL pointer
	image-ext2.c:213:9: warning: Using plain integer as NULL pointer
	image-hd.c:663:11: warning: symbol 'hdimage_opts' was not declared. Should it be static?
	image-iso.c:52:9: warning: Using plain integer as NULL pointer
	image-rauc.c:191:9: warning: Using plain integer as NULL pointer
	image-vfat.c:130:9: warning: Using plain integer as NULL pointer

Note, you might want to also use libconfuse with https://github.com/libconfuse/libconfuse/pull/148, otherwise there are just too many warnings resulting from macros defined there.

If you like this PR it would be great if you label it with `hacktoberfest-accepted` after application.