### PR TITLE
Under some circumstances, FS_IOC_FIEMAP ioctl maybe return -ENOTTY

### DIFF
--- a/util.c
+++ b/util.c
@@ -387,7 +387,7 @@ err_out:
 	free(fiemap);
 
 	/* If failure is due to no filesystem support, return a single extent */
-	if (ret == -EOPNOTSUPP)
+	if ((ret == -EOPNOTSUPP) || (ret == -ENOTTY))
 		return whole_file_exent(size, extents, extent_count);
 
 	image_error(image, "fiemap %s: %d %s\n", filename, errno, strerror(errno));


### PR DESCRIPTION
(possibly on multiarch setup - 32bit userland on 64bit kernel).
This is case isn't exctly an error, instead another variant of
operation not supported. Therefore treat it the same like EOPNOTSUPP.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>