### PR TITLE
allow specifying an image as temporary

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -81,6 +81,12 @@ Here are all options for images:
 		filesystem is created. This option is only used for
 		writeable filesystem types, such as extX, vfat, ubifs and
 		jffs2. This defaults to false.
+:temporary:	If this is set to true, the image is created in
+		``tmppath`` rather than ``outputpath``. This can be
+		useful for intermediate images defined in the
+		configuration file which are not needed by themselves
+		after the main image is created. This defaults to
+		false.
 :exec-pre:	Custom command to run before generating the image.
 :exec-post:	Custom command to run after generating the image.
 :flashtype:	refers to a flash section. Optional for non flash like images

--- a/genimage.c
+++ b/genimage.c
@@ -108,6 +108,7 @@ static cfg_opt_t image_common_opts[] = {
 	CFG_STR("size", NULL, CFGF_NONE),
 	CFG_STR("mountpoint", NULL, CFGF_NONE),
 	CFG_BOOL("empty", cfg_false, CFGF_NONE),
+	CFG_BOOL("temporary", cfg_false, CFGF_NONE),
 	CFG_STR("exec-pre", NULL, CFGF_NONE),
 	CFG_STR("exec-post", NULL, CFGF_NONE),
 	CFG_STR("flashtype", NULL, CFGF_NONE),
@@ -678,12 +679,14 @@ int main(int argc, char *argv[])
 				&image->size_is_percent);
 		image->mountpoint = cfg_getstr(imagesec, "mountpoint");
 		image->empty = cfg_getbool(imagesec, "empty");
+		image->temporary = cfg_getbool(imagesec, "temporary");
 		image->exec_pre = cfg_getstr(imagesec, "exec-pre");
 		image->exec_post = cfg_getstr(imagesec, "exec-post");
 		if (image->file[0] == '/')
 			image->outfile = strdup(image->file);
 		else
-			xasprintf(&image->outfile, "%s/%s", imagepath(),
+			xasprintf(&image->outfile, "%s/%s",
+					image->temporary ? tmppath() : imagepath(),
 					image->file);
 		if (image->mountpoint && *image->mountpoint == '/')
 			image->mountpoint++;

--- a/genimage.h
+++ b/genimage.h
@@ -56,6 +56,7 @@ struct image {
 	cfg_bool_t size_is_percent;
 	const char *mountpoint;
 	cfg_bool_t empty;
+	cfg_bool_t temporary;
 	const char *exec_pre;
 	const char *exec_post;
 	unsigned char partition_type;


### PR DESCRIPTION
When using something like

image @IMAGE@ {
    ....
    partition sysdata {
        image = "sysdata"
	in-partition-table = true
	partition-type-uuid = "L"
    }
}

image sysdata {
    size = 200M
    ext4 {}
    empty = true
}

to create a partition containing an empty file system, it's
undesirable to leave such an empty file system image in the output
directory (especially when building with Yocto, where it then gets
copied to the shared deploy directory).

So allow specifying an image as temporary, putting it in in tmppath()
rather than imagepath().

Signed-off-by: Rasmus Villemoes <rasmus.villemoes@prevas.dk>