### PR TITLE
image-hd: enforce no GPT partition before the primary Partition Entry Array

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -215,9 +215,10 @@ Options:
 			a DOS type partition table is written. Defaults to false.
 :gpt-location:		Location of the GPT table. Occasionally useful for moving the GPT
 			table away from where a bootloader is placed due to hardware
-			requirements.  All partitions in the table must begin after this
-			table.  Regardless of this setting, the GPT header will still be
-			placed at 512 bytes (sector 1).  Defaults to 1024 bytes (sector 2).
+			requirements. All partitions in the table must begin after this
+			table according to the UEFI specification. Regardless of this setting,
+			the GPT header will still be placed at 512 bytes (sector 1).
+			Defaults to 1024 bytes (sector 2).
 :disk-uuid:		UUID string used as disk id in GPT partitioning. Defaults to a
 			random value.
 

--- a/image-hd.c
+++ b/image-hd.c
@@ -602,6 +602,12 @@ static int hdimage_setup(struct image *image, cfg_t *cfg)
 			}
 			part->offset = roundup(now, hd->align);
 		}
+		if (part->in_partition_table && hd->gpt) {
+			if (part->offset < hd->gpt_location + (GPT_SECTORS - 1) * 512) {
+				image_error(image, "part %s cannot be placed before GPT\n", part->name);
+				return -EINVAL;
+			}
+		}
 		if (autoresize) {
 			long long partsize = image->size - now;
 			if (hd->gpt)


### PR DESCRIPTION
A Wandboard (and other iMX platforms) is one of those where the
first stage bootloader is loaded from a hard-coded offset of 1K,
i.e. immediately after the GPT header. So the partition table itself
needs to be moved.

I wanted to get rid of updating the bootloader involving writing to
the raw disk rather than some well-defined partition. Both to reduce
risk of stray writes, and to be able to just use
/dev/disk/by-partlabel/SPL rather than some error-prone "dd
seek=...". Defining a partition at 1K with the GPT moved far out of
the way to 1M actually worked (at least produced an image file that
the linux kernel would happily mount via losetup).

But then I stumbled on the text that says that partitions in the table
must start after the partition table. It wasn't immediately clear if
this was a (historical, as evidently it worked now) limitation of the
genimage implementation or actually mandated. So I looked it up, and
unfortunately, it's the latter:

  The GPT Header defines the range of LBAs that are usable by GPT
  Partition Entries. This range is defined to be inclusive of First
  Usable LBA through Last Usable LBA on the logical device. All data
  stored on the volume must be stored between the First Usable LBA
  through Last Usable LBA, [...]

  The primary GPT Partition Entry Array must be located after the
  primary GPT Header and end before the First Usable LBA.

So update the README to state where that requirement comes from, and
enforce it in the implementation. Since it does seem to work on linux,
we might later add an I-know-what-I'm-doing option to allow such a use
case, but the default should be to generate images according to the spec.

Signed-off-by: Rasmus Villemoes <rasmus.villemoes@prevas.dk>