### PR TITLE
image-hd: allow individual alignment setting for each partition

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -97,10 +97,14 @@ tar, ubi, ubifs, vfat.
 Partition options:
 
 :offset:		The offset of this partition as a total offset to the beginning
-			of the device.
+			of the device. If not given, the partition is placed at the end
+			of the previous partition, rounded up to the partition's
+			``align`` value
 :size:			The size of this partition in bytes. If the size and
 			autoresize are both not set then the size of the partition
 			image is used.
+:align:			Alignment value to use for automatic computation of ``offset``.
+			If not given, the image's ``align`` value is used.
 :partition-type:	Used by dos partition tables to specify the partition type. Using
 			this option with a GPT partition table will create a hybrid MBR partition
 			table with a maximum of 3 partition entries(this limit does not effect the

--- a/genimage.c
+++ b/genimage.c
@@ -90,6 +90,7 @@ static int image_set_handler(struct image *image, cfg_t *cfg)
 static cfg_opt_t partition_opts[] = {
 	CFG_STR("offset", NULL, CFGF_NONE),
 	CFG_STR("size", NULL, CFGF_NONE),
+	CFG_STR("align", NULL, CFGF_NONE),
 	CFG_INT("partition-type", 0, CFGF_NONE),
 	CFG_BOOL("bootable", cfg_false, CFGF_NONE),
 	CFG_BOOL("read-only", cfg_false, CFGF_NONE),
@@ -312,6 +313,7 @@ static int parse_partitions(struct image *image, cfg_t *imagesec)
 		list_add_tail(&part->list, &image->partitions);
 		part->size = cfg_getint_suffix(partsec, "size");
 		part->offset = cfg_getint_suffix(partsec, "offset");
+		part->align = cfg_getint_suffix(partsec, "align");
 		part->partition_type = cfg_getint(partsec, "partition-type");
 		part->bootable = cfg_getbool(partsec, "bootable");
 		part->read_only = cfg_getbool(partsec, "read-only");

--- a/genimage.h
+++ b/genimage.h
@@ -34,6 +34,7 @@ struct mountpoint {
 struct partition {
 	unsigned long long offset;
 	unsigned long long size;
+	unsigned long long align;
 	unsigned char partition_type;
 	cfg_bool_t bootable;
 	cfg_bool_t extended;

--- a/image-hd.c
+++ b/image-hd.c
@@ -600,7 +600,7 @@ static int hdimage_setup(struct image *image, cfg_t *cfg)
 				if (hd->gpt)
 					now = hd->gpt_location + (GPT_SECTORS - 1) * 512;
 			}
-			part->offset = roundup(now, hd->align);
+			part->offset = roundup(now, part->align ?: hd->align);
 		}
 		if (autoresize) {
 			long long partsize = image->size - now;


### PR DESCRIPTION
When building an image that has a combination of some oddball smallish
partitions (say, for containing a U-Boot environment, some firmware
blob, or anything else that just needs a few KB), and a bunch of
partitions meant to hold normal file systems, it can be useful to
ensure those filesystems get aligned on a MB boundary, while not
forcing all the small partitions to effectively occupy a MB each - in
some cases that's not even possible, if for example the artifacts they
contain must all be found within the first MB of the disk.

So allow each partition individually to specify the alignment it
should have. If offset is given explicitly, align is ignored.

Signed-off-by: Rasmus Villemoes <rasmus.villemoes@prevas.dk>