### PR TITLE
Document fill option in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -228,6 +228,10 @@ Options:
                         the image is not written.
 :disk-uuid:		UUID string used as disk id in GPT partitioning. Defaults to a
 			random value.
+:fill:			If this is set to true, then the image file will be filled
+			up to the end of the last partition. This might make the file
+			bigger. This is necessary if the image will be processed by
+			such tools as libvirt, libguestfs or parted.
 
 iso
 ***


### PR DESCRIPTION
The `fill` option is required if hd images are to be processed with programs such as `parted` or `guestfish`.
For instance, without it, parted will abort, stating that the partition end lies beyond the end of the device/file.

However, `fill` is not documented in the README.rst, which makes it hard(er) to find that it exists and is related to the issue.

Adding the option to the README.rst will make `fill` easier to spot.