### PR TITLE
image-hd: align image size to 4k when using GPT

### DIFF
--- a/image-hd.c
+++ b/image-hd.c
@@ -662,8 +662,12 @@ static int hdimage_setup(struct image *image, cfg_t *cfg)
 		return -EINVAL;
 	}
 
-	if (image->size == 0)
-		image->size = now;
+	if (image->size == 0) {
+		if (hd->gpt)
+			image->size = (now + 4095)/4096 * 4096;
+		else
+			image->size = now;
+	}
 
 	image->handler_priv = hd;
 

--- a/test/basic-images.test
+++ b/test/basic-images.test
@@ -258,7 +258,7 @@ fdisk -h | grep -q gpt && test_set_prereq fdisk-gpt
 test_expect_success fdisk-gpt,sfdisk-gpt "hdimage4" "
 	setup_test_images &&
 	run_genimage hdimage4.config test.hdimage &&
-	check_size images/test.hdimage 7356928 &&
+	check_size images/test.hdimage 7360512 &&
 	sfdisk_validate images/test.hdimage &&
 	# check the this identifier
 	fdisk -l images/test.hdimage | grep identifier: > hdimage4.fdisk &&
@@ -271,7 +271,7 @@ test_expect_success fdisk-gpt,sfdisk-gpt "hdimage4" "
 test_expect_success fdisk-gpt,sfdisk-gpt "hdimage5" "
 	setup_test_images &&
 	run_genimage hdimage5.config test.hdimage &&
-	check_size images/test.hdimage 7356928 &&
+	check_size images/test.hdimage 7360512 &&
 	# check the this identifier
 	fdisk -l images/test.hdimage | grep identifier: > hdimage5.fdisk &&
 	# check partitions; filter output to handle different sfdisk versions


### PR DESCRIPTION
The backup partition table at the end of the image for GPT consists of an
odd number of sectors. The size of filesystem images or the explicit size
of a partition is almost always a multiple of 4k. Unless explicitly
configured otherwise, the beginning of all partitions is also multiple of
4k. So when the backup partition table is appended directly after the last
partition then the image size is most likely not a multiple of 4k.
This causes problems with tools such as 'fastboot'.

If the image size is not specified explicitly and GPT is used then increase
the image size if necessary to ensure that it is a multiple of 4k.

Signed-off-by: Michael Olbrich <m.olbrich@pengutronix.de>