### PR TITLE
image-ext: ensure size is always interpreted as kilobytes

### DIFF
--- a/image-ext2.c
+++ b/image-ext2.c
@@ -81,7 +81,7 @@ static int ext2_generate_mke2fs(struct image *image)
 	if (is_block_device(imageoutfile(image)))
 		pad_file(image, NULL, 2048, 0x0, MODE_OVERWRITE);
 
-	return systemp(image, "%s%s -t %s%s -I 256 -E 'root_owner=%s,%s'%s %s%s%s %s %s%s %s%s%s '%s' %lld",
+	return systemp(image, "%s%s -t %s%s -I 256 -E 'root_owner=%s,%s'%s %s%s%s %s %s%s %s%s%s '%s' %lldk",
 			ext->conf_env, get_opt("mke2fs"), image->handler->type,
 			ext->usage_type_args, root_owner, options, ext->size_features,
 			image->empty ? "" : "-d '",


### PR DESCRIPTION
Allow to override block-size from config file.

Signed-off-by: Denis Osterland-Heim <Denis.Osterland@diehl.com>