### PR TITLE
.github: run apt-get update to update package cache

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,6 +24,7 @@ jobs:
 
     - name: Install required packages
       run: |
+        sudo apt-get update
         sudo apt-get install dosfstools fakeroot genext2fs genisoimage libconfuse-dev mtd-utils mtools qemu-utils qemu-utils squashfs-tools ${{ matrix.pkgs }}
 
     - name: Build & Test (with ${{ matrix.options }})


### PR DESCRIPTION
Some repos may become unavailable or move, thus one should always run `apt-get update` prior to `apt-get install`.

Signed-off-by: Enrico Jorns <ejo@pengutronix.de>