### PR TITLE
config: don't try to access non-existent section

### DIFF
--- a/config.c
+++ b/config.c
@@ -197,7 +197,7 @@ int set_config_opts(int argc, char *argv[], cfg_t *cfg)
 	static struct option *long_options = NULL;
 	int ret = 0;
 
-	if (cfg)
+	if (cfg && (cfg_size(cfg, "config") > 0))
 		cfgsec = cfg_getsec(cfg, "config");
 
 	list_for_each_entry(c, &optlist, list) {


### PR DESCRIPTION
If the config file does not include a 'config' section, the parsing
produces a warning: "no sub-section title/index for 'config'".

Silence this by checking if the section exists before accessing it.

Fixes #144

Signed-off-by: Michael Olbrich <m.olbrich@pengutronix.de>