### PR TITLE
image-android-sparse: use off_t instead of int for lseek return values

### DIFF
--- a/image-android-sparse.c
+++ b/image-android-sparse.c
@@ -118,6 +118,7 @@ static int android_sparse_generate(struct image *image)
 	struct extent *extents = NULL;
 	size_t extent_count, extent, block_count, block;
 	int in_fd = -1, out_fd = -1, ret;
+	off_t offset;
 	unsigned int i;
 	uint32_t *buf, *zeros, crc32 = 0;
 	struct stat s;
@@ -223,8 +224,8 @@ static int android_sparse_generate(struct image *image)
 			for (i = 0; i < chunk_header.blocks; ++i)
 				crc32 = crc32_next(zeros, sparse->block_size, crc32);
 		}
-		ret = lseek(in_fd, extents[extent].start, SEEK_SET);
-		if (ret < 0) {
+		offset = lseek(in_fd, extents[extent].start, SEEK_SET);
+		if (offset < 0) {
 			ret = -errno;
 			image_error(image, "seek %s: %s\n", infile, strerror(errno));
 			goto out;
@@ -330,8 +331,8 @@ static int android_sparse_generate(struct image *image)
 	if (ret < 0)
 		goto out;
 
-	ret = lseek(out_fd, 0, SEEK_SET);
-	if (ret < 0) {
+	offset = lseek(out_fd, 0, SEEK_SET);
+	if (offset < 0) {
 		ret = -errno;
 		image_error(image, "seek %s: %s\n", infile, strerror(errno));
 		goto out;


### PR DESCRIPTION
On a 64 bit system off_t can hold signed, 64 bit integers. Putting large off_t values in a 32 bit int results in overflows. These overflows trigger the "< 0" check and result in errors. This can be observed on large input images.

lseek() returns an off_t, so introduce an off_t to store its return value appropriately.