### PR TITLE
util: systemp(): use shell defined in SHELL rather than /bin/sh

### DIFF
--- a/util.c
+++ b/util.c
@@ -216,6 +216,7 @@ int systemp(struct image *image, const char *fmt, ...)
 	pid = fork();
 
 	if (!pid) {
+		const char *shell;
 		int fd;
 
 		if (loglevel() < 1) {
@@ -230,7 +231,11 @@ int systemp(struct image *image, const char *fmt, ...)
 			dup2(STDERR_FILENO, STDOUT_FILENO);
 		}
 
-		ret = execl("/bin/sh", "sh", "-c", buf, NULL);
+		shell = getenv("SHELL");
+		if (!shell || shell[0] == 0x0)
+			shell = "/bin/sh";
+
+		ret = execl(shell, shell, "-c", buf, NULL);
 		if (ret < 0) {
 			ret = -errno;
 			error("Cannot execute %s: %s\n", buf, strerror(errno));


### PR DESCRIPTION
This patch changes systemp() to use the shell defined in the environment
variable SHELL rather then hard coded /bin/sh, so that the called
programs can use shell functions exported in the calling shell. Use
"/bin/sh" as a fall back.

Signed-off-by: Marc Kleine-Budde <mkl@pengutronix.de>