### PR TITLE
util: systemp(): don't use shell defined in SHELL, but GENIMAGE_SHELL

### DIFF
--- a/util.c
+++ b/util.c
@@ -231,7 +231,7 @@ int systemp(struct image *image, const char *fmt, ...)
 			dup2(STDERR_FILENO, STDOUT_FILENO);
 		}
 
-		shell = getenv("SHELL");
+		shell = getenv("GENIMAGE_SHELL");
 		if (!shell || shell[0] == 0x0)
 			shell = "/bin/sh";
 


### PR DESCRIPTION
As Matthias Schiffer (@schiffermtq) pointed out, using SHELL instead
of "/bin/sh" breaks the test suite if not using a POSIX compatible
shell like zsh. Fix this problem by not using blindly SHELL, but
GENIMAGE_SHELL. If this environment variable is set, we assume the
user knows what she's doing.

Link: https://github.com/pengutronix/genimage/pull/161#issuecomment-891761302
Fixes: 1c5301268106 ("util: systemp(): use shell defined in SHELL rather than /bin/sh")
Signed-off-by: Marc Kleine-Budde <mkl@pengutronix.de>