### PR TITLE
.github: replace ubuntu-16.04 with ubuntu-18.04

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,8 +10,8 @@ jobs:
         include:
         - os: ubuntu-20.04
           pkgs: device-tree-compiler rauc simg2img u-boot-tools
-        - os: ubuntu-16.04
-          pkgs: cramfsprogs
+        - os: ubuntu-18.04
+          pkgs: device-tree-compiler simg2img u-boot-tools
 
     steps:
     - name: Inspect environment


### PR DESCRIPTION
It does not give as the same coverage. cramfsprogs is gone and libconfuse
it too new to test the !includepath case.

Still, the various tools have different versions so it's a good test to do
this anyways.

Signed-off-by: Michael Olbrich <m.olbrich@pengutronix.de>