### PR TITLE
handle squashfs image size

### DIFF
--- a/image-hd.c
+++ b/image-hd.c
@@ -457,6 +457,12 @@ static int hdimage_generate(struct image *image)
 		if (child->size == 0)
 			continue;
 
+		if (child->size > part->size) {
+			image_error(image, "part %s size (%lld) too small for %s (%lld)\n",
+				    part->name, part->size, child->file, child->size);
+			return -E2BIG;
+		}
+
 		ret = insert_image(image, child, child->size, part->offset, 0);
 		if (ret) {
 			image_error(image, "failed to write image partition '%s'\n",


### PR DESCRIPTION
When generating a squashfs image as part of an overall image-hd build, the squashfs does not actually get included in the intended partitions. These are an attempt at fixing that. I've tested the patches by seeing that the sd card is now generated as expected, but I don't have time ATM to write proper unit tests for genimage itself.