### PR TITLE
add --configdump option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -566,6 +566,10 @@ variable.
 		directory is searched after these. Thus, if this
 		option is not given, only the current directory is
 		searched. This has no effect when given in the config file.
+:configdump:	File to write the final configuration to. This includes
+		the results of all ``include'' directives, expansions
+		of environment variables and application of default
+		values - think ``gcc -E''.
 
 :cpio:		path to the cpio program (default cpio)
 :dd:		path to the dd program (default dd)

--- a/config.c
+++ b/config.c
@@ -442,6 +442,10 @@ static struct config opts[] = {
 		.name = "config",
 		.env = "GENIMAGE_CONFIG",
 		.def = "genimage.cfg",
+	}, {
+		.name = "configdump",
+		.env = "GENIMAGE_CONFIGDUMP",
+		.def = NULL,
 	},
 };
 

--- a/genimage.c
+++ b/genimage.c
@@ -708,6 +708,21 @@ int main(int argc, char *argv[])
 	/* again, with config file this time */
 	set_config_opts(argc, argv, cfg);
 
+	str = get_opt("configdump");
+	if (str) {
+		FILE *dump;
+
+		dump = (strcmp(str, "-")) ? fopen(str, "w") : stdout;
+		if (!dump) {
+			error("could not open dump file %s: %s", str, strerror(errno));
+			ret = -1;
+			goto cleanup;
+		}
+		cfg_print(cfg, dump);
+		if (dump != stdout)
+			fclose(dump);
+	}
+
 	check_tmp_path();
 
 	ret = systemp(NULL, "rm -rf \"%s\"/*", tmppath());


### PR DESCRIPTION
libconfuse has a cfg_print() function for sort-of pretty-printing a
cfg_t* object. Let's expose that via a --configdump option, to make
debugging of complicated setups with several layers of include() a
little easier.

If I can get it to work, I will also be using the output dump directly
on target, i.e. merely using the host genimage as a preprocessor - so
that I can still reuse include() fragments in my image definition, but
I don't have to copy all those files to target when bootstrapping the
eMMC.

Signed-off-by: Rasmus Villemoes <rasmus.villemoes@prevas.dk>