### PR TITLE
Override filesystem source path

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -80,6 +80,10 @@ Here are all options for images:
 :mountpoint:	mountpoint if image refers to a filesystem image. The
 		default is "/". The content of "${rootpath}${mountpoint}"
 		will be used to fill the filesystem.
+:srcpath:	If this is set, specified path will be directly used
+		to fill the filesystem. Ignoring rootpath/mountpoint logic.
+		Path might be absolute or relative
+		to current working directory.
 :empty:		If this is set to true, then the specified rootpath and
 		mountpoint are ignored for this image and an empty
 		filesystem is created. This option is only used for

--- a/genimage.c
+++ b/genimage.c
@@ -111,6 +111,7 @@ static cfg_opt_t image_common_opts[] = {
 	CFG_STR("name", NULL, CFGF_NONE),
 	CFG_STR("size", NULL, CFGF_NONE),
 	CFG_STR("mountpoint", NULL, CFGF_NONE),
+	CFG_STR("srcpath", NULL, CFGF_NONE),
 	CFG_BOOL("empty", cfg_false, CFGF_NONE),
 	CFG_BOOL("temporary", cfg_false, CFGF_NONE),
 	CFG_STR("exec-pre", NULL, CFGF_NONE),
@@ -474,6 +475,9 @@ static int collect_mountpoints(void)
 
 const char *mountpath(const struct image *image)
 {
+	if(image->srcpath)
+		return image->srcpath;
+
 	struct mountpoint *mp;
 
 	mp = image->mp;
@@ -743,6 +747,7 @@ int main(int argc, char *argv[])
 		image->name = cfg_getstr(imagesec, "name");
 		image->size = cfg_getint_suffix_percent(imagesec, "size",
 				&image->size_is_percent);
+		image->srcpath = cfg_getstr(imagesec, "srcpath");
 		image->mountpoint = cfg_getstr(imagesec, "mountpoint");
 		image->empty = cfg_getbool(imagesec, "empty");
 		image->temporary = cfg_getbool(imagesec, "temporary");
@@ -756,6 +761,10 @@ int main(int argc, char *argv[])
 					image->file);
 		if (image->mountpoint && *image->mountpoint == '/')
 			image->mountpoint++;
+		if (image->srcpath && image->mountpoint && (strlen(image->mountpoint) > 0)) {
+			image_error(image, "Cannot specify both srcpath and mountpoint at the same time.");
+			goto cleanup;
+		}
 		str = cfg_getstr(imagesec, "flashtype");
 		if (str)
 			image->flash_type = flash_type_get(str);

--- a/genimage.h
+++ b/genimage.h
@@ -60,6 +60,7 @@ struct image {
 	int n_holes;
 	cfg_bool_t size_is_percent;
 	const char *mountpoint;
+	const char *srcpath;
 	cfg_bool_t empty;
 	cfg_bool_t temporary;
 	const char *exec_pre;


### PR DESCRIPTION
Fixes #181

Allows user to override the complexity of rootpath/mountpoint and just simply use existing directory at arbitrary path if needed.
Now i can create ext4 filesystem like this:

```
image root.img {
  ext4 {
    label = "rootlabel"
  }
  size = 1024M
  srcdir = "./root"
}
```

`genimage --inputpath "." --outputpath "."`
