### PR TITLE
Add Firmware Image Package (FIP) support

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -24,6 +24,7 @@ genimage_SOURCES = \
 	image-ext2.c \
 	image-f2fs.c \
 	image-file.c \
+	image-fip.c \
 	image-fit.c \
 	image-flash.c \
 	image-hd.c \
@@ -68,6 +69,7 @@ EXTRA_DIST += \
 	test/ext4test.0.dump \
 	test/ext4test.1.dump \
 	test/f2fs.config \
+	test/fip.config \
 	test/fit.its \
 	test/fit.config \
 	test/flash-types.config \

--- a/README.rst
+++ b/README.rst
@@ -500,6 +500,45 @@ Options:
 Note: If no content is specified with ``file`` or ``files`` then
 ``rootpath`` and ``mountpoint`` are used to provide the content.
 
+fip
+***
+Generates a Firmware Image Package (FIP). A format used to bundle
+firmware to be loaded by ARM Trusted Firmware.
+
+Options:
+
+:extraargs:		Extra arguments passed to fiptool
+:fw-config:		Firmware Configuration (device tree), usually provided by BL2 (Trusted Firmware)
+:nt-fw:			Non-Trusted Firmware (BL33)
+:hw-config:		Hardware Configuration (device tree), passed to BL33
+:tos-fw:		Trusted OS (BL32) binaries. Second and third binary are used as
+			extra1 and extra2 binaries if specified. Example:
+			``tos-fw = {"tee-header_v2.bin", "tee-pager_v2.bin", "tee-pageable_v2.bin"}``
+:scp-fwu-cfg:		SCP Firmware Updater Configuration FWU SCP_BL2U
+:ap-fwu-cfg:		AP Firmware Updater Configuration BL2U
+:fwu:			Firmware Updater NS_BL2U
+:fwu-cert:		Non-Trusted Firmware Updater certificate
+:tb-fw:			Trusted Boot Firmware BL2
+:scp-fw:		SCP Firmware SCP_BL2
+:soc-fw:		EL3 Runtime Firmware BL31
+:tb-fw-config:		TB_FW_CONFIG
+:soc-fw-config:		SOC_FW_CONFIG
+:tos-fw-config:		TOS_FW_CONFIG
+:nt-fw-config:		NT_FW_CONFIG
+:rot-cert:		Root Of Trust key certificate
+:trusted-key-cert:	Trusted key certificate
+:scp-fw-key-cert:	SCP Firmware key certificate
+:soc-fw-key-cert:	SoC Firmware key certificate
+:tos-fw-key-cert:	Trusted OS Firmware key certificate
+:nt-fw-key-cert:	Non-Trusted Firmware key certificate
+:tb-fw-cert:		Trusted Boot Firmware BL2 certificate
+:scp-fw-cert:		SCP Firmware content certificate
+:soc-fw-cert:		SoC Firmware content certificate
+:tos-fw-cert:		Trusted OS Firmware content certificate
+:nt-fw-cert:		Non-Trusted Firmware content certificate
+:sip-sp-cert:		SiP owned Secure Partition content certificate
+:plat-sp-cert:		Platform owned Secure Partition content certificate
+
 The Flash Section
 -----------------
 

--- a/config.c
+++ b/config.c
@@ -454,6 +454,11 @@ static struct config opts[] = {
 		.env = "GENIMAGE_MKIMAGE",
 		.def = "mkimage",
 	}, {
+		.name = "fiptool",
+		.opt = CFG_STR("fiptool", NULL, CFGF_NONE),
+		.env = "GENIMAGE_FIPTOOL",
+		.def = "fiptool",
+	}, {
 		.name = "config",
 		.env = "GENIMAGE_CONFIG",
 		.def = "genimage.cfg",

--- a/genimage.c
+++ b/genimage.c
@@ -47,6 +47,7 @@ static struct image_handler *handlers[] = {
 	&f2fs_handler,
 	&file_handler,
 	&fit_handler,
+	&fip_handler,
 	&flash_handler,
 	&hdimage_handler,
 	&iso_handler,

--- a/genimage.h
+++ b/genimage.h
@@ -122,6 +122,7 @@ extern struct image_handler ubi_handler;
 extern struct image_handler ubifs_handler;
 extern struct image_handler vfat_handler;
 extern struct image_handler fit_handler;
+extern struct image_handler fip_handler;
 
 #define ARRAY_SIZE(arr)		(sizeof(arr) / sizeof((arr)[0]))
 

--- a/image-fip.c
+++ b/image-fip.c
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2022 Ahmad Fatoum <a.fatoum@pengutronix.de>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <confuse.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <errno.h>
+
+#include "genimage.h"
+
+static int fip_generate(struct image *image)
+{
+	struct partition *part;
+	char *args = strdup("");
+	const char *extraargs = cfg_getstr(image->imagesec, "extraargs");
+	int ret;
+
+	list_for_each_entry(part, &image->partitions, list) {
+		struct image *child = image_get(part->image);
+		char *oldargs;
+
+		oldargs = args;
+		xasprintf(&args, "%s --%s '%s'", args, part->name, imageoutfile(child));
+		free(oldargs);
+	}
+
+	ret = systemp(image, "%s create %s %s '%s'", get_opt("fiptool"),
+		      args, extraargs, imageoutfile(image));
+
+	free(args);
+
+	return ret;
+}
+
+static void fip_add_part(struct image *image,
+			 const char *name, const char *path)
+{
+	struct partition *part;
+
+	part = xzalloc(sizeof *part);
+	part->image = path;
+	part->name = name;
+	list_add_tail(&part->list, &image->partitions);
+}
+
+static cfg_opt_t fip_opts[] = {
+	CFG_STR("extraargs",		"", CFGF_NONE),
+	CFG_STR_LIST("tos-fw",		NULL, CFGF_NONE),	/* Secure Payload BL32 (Trusted OS, Extra1, Extra 2) */
+	/* CFGF_NODEFAULT marks options passed as-is */
+	CFG_STR("scp-fwu-cfg",		NULL, CFGF_NODEFAULT),	/* SCP Firmware Updater Configuration FWU SCP_BL2U */
+	CFG_STR("ap-fwu-cfg",		NULL, CFGF_NODEFAULT),	/* AP Firmware Updater Configuration BL2U */
+	CFG_STR("fwu",			NULL, CFGF_NODEFAULT),	/* Firmware Updater NS_BL2U */
+	CFG_STR("fwu-cert",		NULL, CFGF_NODEFAULT),	/* Non-Trusted Firmware Updater certificate */
+	CFG_STR("tb-fw",		NULL, CFGF_NODEFAULT),	/* Trusted Boot Firmware BL2 */
+	CFG_STR("scp-fw",		NULL, CFGF_NODEFAULT),	/* SCP Firmware SCP_BL2 */
+	CFG_STR("soc-fw",		NULL, CFGF_NODEFAULT),	/* EL3 Runtime Firmware BL31 */
+	CFG_STR("nt-fw",		NULL, CFGF_NODEFAULT),	/* Non-Trusted Firmware BL33 */
+	CFG_STR("fw-config",		NULL, CFGF_NODEFAULT),	/* FW_CONFIG */
+	CFG_STR("hw-config",		NULL, CFGF_NODEFAULT),	/* HW_CONFIG */
+	CFG_STR("tb-fw-config",		NULL, CFGF_NODEFAULT),	/* TB_FW_CONFIG */
+	CFG_STR("soc-fw-config",	NULL, CFGF_NODEFAULT),	/* SOC_FW_CONFIG */
+	CFG_STR("tos-fw-config",	NULL, CFGF_NODEFAULT),	/* TOS_FW_CONFIG */
+	CFG_STR("nt-fw-config",		NULL, CFGF_NODEFAULT),	/* NT_FW_CONFIG */
+
+	CFG_STR("rot-cert",		NULL, CFGF_NODEFAULT),	/* Root Of Trust key certificate */
+
+	CFG_STR("trusted-key-cert",	NULL, CFGF_NODEFAULT),	/* Trusted key certificate */
+	CFG_STR("scp-fw-key-cert",	NULL, CFGF_NODEFAULT),	/* SCP Firmware key certificate */
+	CFG_STR("soc-fw-key-cert",	NULL, CFGF_NODEFAULT),	/* SoC Firmware key certificate */
+	CFG_STR("tos-fw-key-cert",	NULL, CFGF_NODEFAULT),	/* Trusted OS Firmware key certificate */
+	CFG_STR("nt-fw-key-cert",	NULL, CFGF_NODEFAULT),	/* Non-Trusted Firmware key certificate */
+
+	CFG_STR("tb-fw-cert",		NULL, CFGF_NODEFAULT),	/* Trusted Boot Firmware BL2 certificate */
+	CFG_STR("scp-fw-cert",		NULL, CFGF_NODEFAULT),	/* SCP Firmware content certificate */
+	CFG_STR("soc-fw-cert",		NULL, CFGF_NODEFAULT),	/* SoC Firmware content certificate */
+	CFG_STR("tos-fw-cert",		NULL, CFGF_NODEFAULT),	/* Trusted OS Firmware content certificate */
+	CFG_STR("nt-fw-cert",		NULL, CFGF_NODEFAULT),	/* Non-Trusted Firmware content certificate */
+
+	CFG_STR("sip-sp-cert",		NULL, CFGF_NODEFAULT),	/* SiP owned Secure Partition content certificate */
+	CFG_STR("plat-sp-cert",		NULL, CFGF_NODEFAULT),	/* Platform owned Secure Partition content certificate */
+
+	CFG_END()
+};
+
+static const char *tos_fw[] = { "tos-fw", "tos-fw-extra1", "tos-fw-extra2" };
+
+static int fip_parse(struct image *image, cfg_t *cfg)
+{
+	unsigned int i, num_tos_fw;
+	cfg_opt_t *opt;
+
+	num_tos_fw = cfg_size(cfg, "tos-fw");
+	if (num_tos_fw > ARRAY_SIZE(tos_fw)) {
+		image_error(image, "%u tos-fw binaries given, but maximum is %zu\n",
+			    num_tos_fw, ARRAY_SIZE(tos_fw));
+		return -EINVAL;
+	}
+
+	for (i = 0; i < num_tos_fw; i++)
+		fip_add_part(image, tos_fw[i], cfg_getnstr(cfg, "tos-fw", i));
+
+	for (opt = fip_opts; opt->type; opt++) {
+		const char *file;
+
+		if (opt->flags != CFGF_NODEFAULT)
+			continue;
+
+		file = cfg_getstr(cfg, opt->name);
+		if (file)
+			fip_add_part(image, opt->name, file);
+	}
+
+	return 0;
+}
+
+struct image_handler fip_handler = {
+	.type = "fip",
+	.no_rootpath = cfg_true,
+	.generate = fip_generate,
+	.parse = fip_parse,
+	.opts = fip_opts,
+};

--- a/test/basic-images.test
+++ b/test/basic-images.test
@@ -564,6 +564,14 @@ test_expect_success !includepath "includepath5" "
 "
 
 
+exec_test_set_prereq fiptool
+test_expect_success fiptool "fip" "
+	setup_test_images &&
+	run_genimage fip.config test.fip &&
+	check_size_range images/test.fip 12804 13056 &&
+	fiptool info images/test.fip
+"
+
 test_done
 
 # vim: syntax=sh

--- a/test/fip.config
+++ b/test/fip.config
@@ -1,0 +1,7 @@
+image test.fip {
+	fip {
+		extraargs = "--align 64"
+		fw-config = "part1.img"
+		tos-fw = { "part2.img", "part1.img" }
+	}
+}


### PR DESCRIPTION
```
Platforms where ARM Trusted Firmware is the first stage bootloader are
converging to use FIP as bundle format for further firmware including
trusted OS and non secure bootloader. Teach genimage to call fiptool to
generate FIP images. The config options currently supported by genimage
for fip { } nodes are those needed to boot the STM32MP1. The extraargs
config option can be used to add further options as a stop-gap until
genimage is extended as necessary.

Signed-off-by: Ahmad Fatoum <a.fatoum@pengutronix.de>
```