### PR TITLE
Fix Image Environment

### DIFF
--- a/genimage.c
+++ b/genimage.c
@@ -301,6 +301,10 @@ static int image_generate(struct image *image)
 		}
 	}
 
+	ret = setenv_image(image);
+	if (ret)
+		return ret;
+
 	if (image->exec_pre) {
 		ret = systemp(image, "%s", image->exec_pre);
 		if (ret)
@@ -853,10 +857,6 @@ int main(int argc, char *argv[])
 		goto cleanup;
 
 	list_for_each_entry(image, &images, list) {
-		ret = setenv_image(image);
-		if (ret)
-			goto cleanup;
-
 		ret = image_generate(image);
 		if (ret) {
 			image_error(image, "failed to generate %s\n", image->file);

--- a/genimage.c
+++ b/genimage.c
@@ -198,6 +198,74 @@ static int image_setup(struct image *image)
 	return 0;
 }
 
+static int overwriteenv(const char *name, const char *value)
+{
+	int ret;
+
+	ret = setenv(name, value ? : "", 1);
+	if (ret)
+		return -errno;
+
+	return 0;
+}
+
+static int setenv_paths(void)
+{
+	int ret;
+
+	ret = overwriteenv("OUTPUTPATH", imagepath());
+	if (ret)
+		return ret;
+
+	ret = overwriteenv("INPUTPATH", inputpath());
+	if (ret)
+		return ret;
+
+	ret = overwriteenv("ROOTPATH", rootpath());
+	if (ret)
+		return ret;
+
+	ret = overwriteenv("TMPPATH", tmppath());
+	if (ret)
+		return ret;
+
+	return 0;
+}
+
+static int setenv_image(const struct image *image)
+{
+	int ret;
+	char sizestr[20];
+
+	snprintf(sizestr, sizeof(sizestr), "%llu", image->size);
+
+	ret = overwriteenv("IMAGE", image->file);
+	if (ret)
+		return ret;
+
+	ret = overwriteenv("IMAGEOUTFILE", imageoutfile(image));
+	if (ret)
+		return ret;
+
+	ret = overwriteenv("IMAGENAME", image->name);
+	if (ret)
+		return ret;
+
+	ret = overwriteenv("IMAGESIZE", sizestr);
+	if (ret)
+		return ret;
+
+	ret = overwriteenv("IMAGEMOUNTPOINT", image->mountpoint);
+	if (ret)
+		return ret;
+
+	ret = overwriteenv("IMAGEMOUNTPATH", image->empty ? NULL : mountpath(image));
+	if (ret)
+		return ret;
+
+	return 0;
+}
+
 /*
  * generate the images. Calls ->generate function for each
  * image, recursively calls itself for resolving dependencies
@@ -550,74 +618,6 @@ static cfg_opt_t top_opts[] = {
 	CFG_FUNC("include", &cfg_include),
 	CFG_END()
 };
-
-static int overwriteenv(const char *name, const char *value)
-{
-	int ret;
-
-	ret = setenv(name, value ? : "", 1);
-	if (ret)
-		return -errno;
-
-	return 0;
-}
-
-static int setenv_paths(void)
-{
-	int ret;
-
-	ret = overwriteenv("OUTPUTPATH", imagepath());
-	if (ret)
-		return ret;
-
-	ret = overwriteenv("INPUTPATH", inputpath());
-	if (ret)
-		return ret;
-
-	ret = overwriteenv("ROOTPATH", rootpath());
-	if (ret)
-		return ret;
-
-	ret = overwriteenv("TMPPATH", tmppath());
-	if (ret)
-		return ret;
-
-	return 0;
-}
-
-static int setenv_image(const struct image *image)
-{
-	int ret;
-	char sizestr[20];
-
-	snprintf(sizestr, sizeof(sizestr), "%llu", image->size);
-
-	ret = overwriteenv("IMAGE", image->file);
-	if (ret)
-		return ret;
-
-	ret = overwriteenv("IMAGEOUTFILE", imageoutfile(image));
-	if (ret)
-		return ret;
-
-	ret = overwriteenv("IMAGENAME", image->name);
-	if (ret)
-		return ret;
-
-	ret = overwriteenv("IMAGESIZE", sizestr);
-	if (ret)
-		return ret;
-
-	ret = overwriteenv("IMAGEMOUNTPOINT", image->mountpoint);
-	if (ret)
-		return ret;
-
-	ret = overwriteenv("IMAGEMOUNTPATH", image->empty ? NULL : mountpath(image));
-	if (ret)
-		return ret;
-
-	return 0;
-}
 
 #ifdef HAVE_SEARCHPATH
 static int add_searchpath(cfg_t *cfg, const char *dir)


### PR DESCRIPTION
A set of image environment variables can be used in `exec-pre` and `exec-post`. This "image environment" is specific to the image being generated. `image_generate()` calls itself recursively to resolve dependencies. Because `setenv_image()` is called before `image_generate()`, the set image environment is wrong as soon as `image_generate()` calls itself.

Fix that by setting the image environment inside `image_generate(`) after the point it might call itself for dependency resolution. This way the image environment is always correct.