### PR TITLE
test: mke2fs: fully disable quota in the test

### DIFF
--- a/test/ext.test
+++ b/test/ext.test
@@ -1,5 +1,4 @@
 #!/bin/bash
-set -x
 test_description="extX Image Tests"
 
 . "$(dirname "${0}")/test-setup.sh"

--- a/test/filesystem.test
+++ b/test/filesystem.test
@@ -1,5 +1,4 @@
 #!/bin/bash
-set -x
 test_description="Filesystem Image Tests"
 
 . "$(dirname "${0}")/test-setup.sh"

--- a/test/flash.test
+++ b/test/flash.test
@@ -1,5 +1,4 @@
 #!/bin/bash
-set -x
 test_description="Flash Image Tests"
 
 . "$(dirname "${0}")/test-setup.sh"

--- a/test/genimage.test
+++ b/test/genimage.test
@@ -1,5 +1,4 @@
 #!/bin/bash
-set -x
 test_description="Genimage Basic Functionality Tests"
 
 . "$(dirname "${0}")/test-setup.sh"

--- a/test/hdimage.test
+++ b/test/hdimage.test
@@ -1,5 +1,4 @@
 #!/bin/bash
-set -x
 test_description="hdimage Image Tests"
 
 . "$(dirname "${0}")/test-setup.sh"

--- a/test/misc.test
+++ b/test/misc.test
@@ -1,5 +1,4 @@
 #!/bin/bash
-set -x
 test_description="Misc Image Tests"
 
 . "$(dirname "${0}")/test-setup.sh"

--- a/test/mke2fs.0.dump
+++ b/test/mke2fs.0.dump
@@ -11,7 +11,7 @@ Filesystem OS type:       Linux
 Inode count:              8192
 Block count:              32768
 Reserved block count:     1638
-Free blocks:              26568
+Free blocks:              26580
 Free inodes:              8141
 First block:              1
 Block size:               1024
@@ -29,7 +29,7 @@ Mount count:              0
 Maximum mount count:      -1
 Last checked:             Sat Jan  1 00:00:00 2000
 Check interval:           0 (<none>)
-Lifetime writes:          141 kB
+Lifetime writes:          107 kB
 Reserved blocks uid:      0 (user root)
 Reserved blocks gid:      0 (group root)
 First inode:              11
@@ -39,8 +39,6 @@ Desired extra isize:      32
 Journal inode:            8
 Default directory hash:   half_md4
 Journal backup:           inode blocks
-User quota inode:         3
-Group quota inode:        4
 Checksum type:            crc32c
 Journal features:         (none)
 Total journal size:       4096k
@@ -51,13 +49,13 @@ Journal sequence:         0x00000001
 Journal start:            0
 
 
-Group 0: (Blocks 1-8192) csum 0x74a0 [ITABLE_ZEROED]
+Group 0: (Blocks 1-8192) csum 0xd0bb [ITABLE_ZEROED]
   Primary superblock at 1, Group descriptors at 2-2
-  Block bitmap at 3 (+2), csum 0x16cec4db
+  Block bitmap at 3 (+2), csum 0xde29f1cb
   Inode bitmap at 7 (+6), csum 0xb1052088
   Inode table at 11-522 (+10)
-  6093 free blocks, 1997 free inodes, 18 directories, 1997 unused inodes
-  Free blocks: 2100-8192
+  6105 free blocks, 1997 free inodes, 18 directories, 1997 unused inodes
+  Free blocks: 2088-8192
   Free inodes: 52-2048
 Group 1: (Blocks 8193-16384) csum 0x8fde [INODE_UNINIT, BLOCK_UNINIT, ITABLE_ZEROED]
   Backup superblock at 8193, Group descriptors at 8194-8194

--- a/test/mke2fs.config
+++ b/test/mke2fs.config
@@ -4,7 +4,7 @@ image mke2fs.ext4 {
 		fs-timestamp = "20000101000000"
 		use-mke2fs = true
 		mke2fs-conf = "mke2fs.conf"
-		extraargs = "-U 12345678-1234-1234-1234-1234567890ab"
+		extraargs = "-U 12345678-1234-1234-1234-1234567890ab -E quotatype="
 		features = "^resize_inode,quota"
 	}
 	size = 32M


### PR DESCRIPTION
The test disabled quota for better reproducibility. But it seems some quota
stuff remains. And at leasts with mke2fs 1.46.2 on x86_64 the resulting
image seems to be inconsistent. At least e2fsck complains about a quota
issue:

[QUOTA WARNING] Usage inconsistent for ID 0:actual (29696, 42) != expected (13312, 2)
mke2fs: Update quota info for quota type 0.
[QUOTA WARNING] Usage inconsistent for ID 0:actual (29696, 42) != expected (13312, 2)
mke2fs: Update quota info for quota type 1.

For some reason this does not happen on 32 bit architectures. So the
resulting image is different and the check fails.

Avoid this whole mess by adding '-E quotatype=' to the mke2fs arguments.
This way quota is fully disabled, e2fsck is happy and the resulting
filesystem is the same on all architectures.

Fixes: #200