### PR TITLE
fix building without fallocate()

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,6 +13,7 @@ jobs:
         - os: ubuntu-22.04
           pkgs: device-tree-compiler rauc simg2img u-boot-tools f2fs-tools arm-trusted-firmware-tools
           fake: sudo rm /usr/include/linux/fiemap.h /usr/include/linux/fs.h
+          env: ac_cv_func_fallocate=no
         - os: ubuntu-20.04
           pkgs: device-tree-compiler rauc simg2img u-boot-tools f2fs-tools
         - os: ubuntu-18.04
@@ -37,7 +38,7 @@ jobs:
       run: |
         ./autogen.sh
         ./configure
-        AM_COLOR_TESTS=always make distcheck
+        ${{ matrix.env }} M_COLOR_TESTS=always make distcheck
 
     - name: Dump test log
       if: ${{ failure() }}

--- a/configure.ac
+++ b/configure.ac
@@ -46,6 +46,8 @@ if test "x$genimage_cv_header_fiemap_h" = "xyes" -a "x$genimage_cv_header_linux_
 	AC_DEFINE([HAVE_FIEMAP], [1], [Define if fiemap can be used])
 fi
 
+AC_CHECK_FUNCS(fallocate)
+
 # ----------- query user's settings ----------------------
 AC_MSG_CHECKING([whether to enable debugging])
 AC_ARG_ENABLE([debug],

--- a/util.c
+++ b/util.c
@@ -465,16 +465,16 @@ static int write_bytes(int fd, size_t size, off_t offset, unsigned char byte)
 			 */
 			size = st.st_size - offset;
 		}
+#ifdef HAVE_FALLOCATE
 		/*
-		 * Maybe this should be guarded by a #ifdef
-		 * HAVE_FALLOCATE. That's easy to add, and the code
-		 * will just automatically fall through to the write
-		 * loop, the same way as if the filesystem doesn't
-		 * support FALLOC_FL_PUNCH_HOLE.
+		 * Use fallocate if it is available and FALLOC_FL_PUNCH_HOLE
+		 * is supported by the filesystem. If not, fall through to
+		 * the write loop.
 		 */
 		if (fallocate(fd, FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE,
 			      offset, size) == 0)
 			return 0;
+#endif
 	}
 
 	/* Not a regular file, non-zero pattern, or fallocate not applicable. */


### PR DESCRIPTION
It is not available on BSD so add a configure check for it. We already have fallback code in case fallocate() fails, so reuse that when it is missing.

Fixes: #202

Signed-off-by: Michael Olbrich <m.olbrich@pengutronix.de>