### PR TITLE
make insert_data take an "unsigned long long" offset

### DIFF
--- a/genimage.h
+++ b/genimage.h
@@ -174,7 +174,7 @@ int insert_image(struct image *image, struct image *sub,
 		 unsigned long long size, unsigned long long offset,
 		 unsigned char byte);
 int insert_data(struct image *image, const void *data, const char *outfile,
-		size_t size, long offset);
+		size_t size, unsigned long long offset);
 int extend_file(struct image *image, size_t size);
 int reload_partitions(struct image *image);
 int parse_holes(struct image *image, cfg_t *cfg);

--- a/util.c
+++ b/util.c
@@ -642,7 +642,7 @@ out:
 }
 
 int insert_data(struct image *image, const void *_data, const char *outfile,
-		size_t size, long offset)
+		size_t size, unsigned long long offset)
 {
 	const char *data = _data;
 	int outf = -1;


### PR DESCRIPTION
When using genimage on a 32 bit host and trying to populate a ~8GiB eMMC with a GPT image, we hit

INFO: hdimage(/dev/mmcblk0): determined size of block device /dev/mmcblk0 to be 7820083200 ...
ERROR: hdimage(/dev/mmcblk0): seek /dev/mmcblk0: Invalid argument ERROR: hdimage(/dev/mmcblk0): failed to write backup GPT table

This is because the "image->size - GPT_SECTORS*512" aka 7820066304 passed from hdimage_insert_gpt() becomes -769868288 when shoehorned into a "signed long".

Make the offset parameter "unsigned long long" to match the protoype of insert_image().

Signed-off-by: Rasmus Villemoes <rasmus.villemoes@prevas.dk>