### PR TITLE
image-hd: implement "fill" option for partitions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -120,6 +120,9 @@ Partition options:
 			table, otherwise to the image's ``align`` value.
 :partition-type:	Used by dos partition tables to specify the partition type.
 :image:			The image file this partition shall be filled with
+:fill:			Boolean specifying that all bytes of the partition should be
+			explicitly initialized. Any bytes beyond the size of the specified
+			image will be set to 0.
 :autoresize:		Boolean specifying that the partition should be resized
 			automatically. For UBI volumes this means that the
 			``autoresize`` flag is set. Only one volume can have this flag.

--- a/genimage.c
+++ b/genimage.c
@@ -99,6 +99,7 @@ static cfg_opt_t partition_opts[] = {
 	CFG_BOOL("read-only", cfg_false, CFGF_NONE),
 	CFG_BOOL("hidden", cfg_false, CFGF_NONE),
 	CFG_BOOL("no-automount", cfg_false, CFGF_NONE),
+	CFG_BOOL("fill", cfg_false, CFGF_NONE),
 	CFG_STR("image", NULL, CFGF_NONE),
 	CFG_STR_LIST("holes", NULL, CFGF_NONE),
 	CFG_BOOL("autoresize", 0, CFGF_NONE),
@@ -398,6 +399,7 @@ static int parse_partitions(struct image *image, cfg_t *imagesec)
 		part->read_only = cfg_getbool(partsec, "read-only");
 		part->hidden = cfg_getbool(partsec, "hidden");
 		part->no_automount = cfg_getbool(partsec, "no-automount");
+		part->fill = cfg_getbool(partsec, "fill");
 		part->image = cfg_getstr(partsec, "image");
 		part->autoresize = cfg_getbool(partsec, "autoresize");
 		part->in_partition_table = cfg_getbool(partsec, "in-partition-table");

--- a/genimage.h
+++ b/genimage.h
@@ -43,6 +43,7 @@ struct partition {
 	cfg_bool_t read_only;
 	cfg_bool_t hidden;
 	cfg_bool_t no_automount;
+	cfg_bool_t fill;
 	const char *image;
 	struct list_head list;
 	int autoresize;

--- a/image-hd.c
+++ b/image-hd.c
@@ -434,7 +434,7 @@ static int hdimage_generate(struct image *image)
 
 		child = image_get(part->image);
 
-		if (child->size == 0)
+		if (child->size == 0 && !part->fill)
 			continue;
 
 		if (child->size > part->size) {
@@ -443,7 +443,7 @@ static int hdimage_generate(struct image *image)
 			return -E2BIG;
 		}
 
-		ret = insert_image(image, child, child->size, part->offset, 0);
+		ret = insert_image(image, child, part->fill ? part->size : child->size, part->offset, 0);
 		if (ret) {
 			image_error(image, "failed to write image partition '%s'\n",
 					part->name);


### PR DESCRIPTION
When bootstrapping, it can be useful to ensure that a partition has completely known contents, especially when the partition just contains raw binary data and not a filesystem.

When generating an image file, this is implicitly done already because the non-written parts of the partition(s) are implicitly zero-filled when the containing image file is extended to its final size.

But when using genimage to directly populate a block device, no such implicit zero-filling is done.

Add a "fill" boolean option, and use that to decide between passing the partition's size or the child image's size to insert_image().