### PR TITLE
autoconf: Update scripts for newer versions of autoconf.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -7,7 +7,7 @@ AC_INIT([genimage],
 AC_CONFIG_SRCDIR([genimage.c])
 AC_CONFIG_AUX_DIR([build-aux])
 AM_INIT_AUTOMAKE([foreign 1.11 -Wall -Wno-portability silent-rules tar-pax no-dist-gzip dist-xz subdir-objects])
-AC_PROG_CC_STDC
+AC_PROG_CC
 
 # If possible, enable extensions to Posix
 AC_USE_SYSTEM_EXTENSIONS

--- a/m4/attributes.m4
+++ b/m4/attributes.m4
@@ -89,7 +89,7 @@ AC_DEFUN([CC_CHECK_LDFLAGS], [
     AS_TR_SH([cc_cv_ldflags_$1]),
     [ac_save_LDFLAGS="$LDFLAGS"
      LDFLAGS="$LDFLAGS $1"
-     AC_LINK_IFELSE([int main() { return 1; }],
+     AC_LINK_IFELSE([AC_LANG_SOURCE([int main() { return 1; }])],
        [eval "AS_TR_SH([cc_cv_ldflags_$1])='yes'"],
        [eval "AS_TR_SH([cc_cv_ldflags_$1])="])
      LDFLAGS="$ac_save_LDFLAGS"


### PR DESCRIPTION
* `AC_LINK_IFELSE` without `AC_LANG_SOURCE` is deprecated since somewhen around version 2.68.
* `AC_PROG_CC_STDC` has been deprecated In favor of `AC_PROG_CC` with version 2.70. The necessary options for standard C are now determined and added automatically.