### PR TITLE
GitHub Actions Maintenance

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,8 +16,6 @@ jobs:
           env: ac_cv_func_fallocate=no
         - os: ubuntu-20.04
           pkgs: device-tree-compiler rauc simg2img u-boot-tools f2fs-tools
-        - os: ubuntu-18.04
-          pkgs: device-tree-compiler simg2img u-boot-tools f2fs-tools
 
     steps:
     - name: Inspect environment

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs:
         lsb_release -a
         gcc --version
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Install required packages
       run: |


### PR DESCRIPTION
Some builds have been erroring or producing warnings, this PR should fix them.

* remove tests on deprecated ubuntu-18.04 image
* upgrade actions to Node 16
