### PR TITLE
Guarantee 0-holes in sparse files are filled with `0` bytes in flash images

### DIFF
--- a/util.c
+++ b/util.c
@@ -585,7 +585,7 @@ int insert_image(struct image *image, struct image *sub,
 		 * have an extent that starts beyond size.
 		 */
 		len = min(len, size);
-		ret = write_bytes(fd, len, offset, byte);
+		ret = write_bytes(fd, len, offset, 0); // Assumes 'holes' are always 0 bytes
 		if (ret) {
 			image_error(image, "writing %zu bytes failed: %s\n", len, strerror(-ret));
 			goto out;


### PR DESCRIPTION
Fixes #221 

Tested this fix using the example that inspired #221, verified that holes in sparse input files are now correctly populated with 0-bytes in the generated flash image, and that nothing else in the generated image changed.