### PR TITLE
image-android-sparse: Fix #224: truncated image generated

### DIFF
--- a/image-android-sparse.c
+++ b/image-android-sparse.c
@@ -317,7 +317,7 @@ static int android_sparse_generate(struct image *image)
 		ret = flush_header(image, out_fd, &chunk_header, pos);
 		if (ret < 0)
 			return ret;
-		block = extents[extent].end / sparse->block_size;
+		block = (extents[extent].end - 1 + sparse->block_size) / sparse->block_size;
 	}
 
 	if (block < block_count) {

--- a/image-android-sparse.c
+++ b/image-android-sparse.c
@@ -320,6 +320,19 @@ static int android_sparse_generate(struct image *image)
 		block = extents[extent].end / sparse->block_size;
 	}
 
+	if (block < block_count) {
+		header.input_chunks++;
+		chunk_header.chunk_type = SPARSE_DONT_CARE;
+		chunk_header.blocks = block_count - block;
+		chunk_header.size = sizeof(chunk_header);
+		ret = flush_header(image, out_fd, &chunk_header, -1);
+		if (ret < 0)
+			return ret;
+
+		for (i = 0; i < chunk_header.blocks; ++i)
+			crc32 = crc32_next(zeros, sparse->block_size, crc32);
+	}
+
 	header.input_chunks++;
 	chunk_header.chunk_type = SPARSE_CRC32;
 	chunk_header.blocks = 0;

--- a/test/misc.test
+++ b/test/misc.test
@@ -67,15 +67,22 @@ test_expect_success rauc "rauc" "
 exec_test_set_prereq simg2img
 test_expect_success simg2img "android-sparse" "
 	setup_test_images &&
+	# make sure there is a 4*32k hole at the end
+	i=16
+	truncate --size=\$[i*(i+1)*i*i*512+32768*4] input/interleaved
 	for i in \`seq 16\`; do
 		dd if=/dev/urandom of=input/interleaved conv=notrunc seek=\$[i*i] count=\$[i] bs=\$[i*i*512] || break
 	done &&
+	dd if=/dev/urandom of=input/not-aligned count=9 bs=1024
 	run_genimage sparse.config &&
-	md5sum images/test.hdimage input/interleaved > md5sum &&
-	rm images/test.hdimage input/interleaved &&
-	check_size_range images/interleaved.sparse 9732464 9732608 &&
+	# simg2img will expand the partial block
+	truncate --size=12k input/not-aligned
+	md5sum images/test.hdimage input/interleaved input/not-aligned > md5sum &&
+	rm images/test.hdimage input/interleaved input/not-aligned &&
+	check_size_range images/interleaved.sparse 9732464 9732636 &&
 	simg2img images/test.sparse images/test.hdimage &&
 	simg2img images/interleaved.sparse input/interleaved &&
+	simg2img images/not-aligned.sparse input/not-aligned &&
 	md5sum -c md5sum
 "
 

--- a/test/sparse.config
+++ b/test/sparse.config
@@ -30,3 +30,10 @@ image interleaved.sparse {
 		block-size = 32k
 	}
 }
+
+image not-aligned.sparse {
+	android-sparse {
+		image = not-aligned
+		block-size = 4k
+	}
+}


### PR DESCRIPTION
This is  #225 with tests and another fix.