### PR TITLE
test: hdimage: depend on fdisk and sfdisk

### DIFF
--- a/test/hdimage.test
+++ b/test/hdimage.test
@@ -118,7 +118,7 @@ test_expect_success "gpt-overlap3" "
 	setup_gpt_files &&
 	test_must_fail run_genimage gpt-overlap3.config"
 
-test_expect_success "gpt-partition-types" "
+test_expect_success fdisk,sfdisk "gpt-partition-types" "
 	run_genimage gpt-partition-types.config &&
 	sfdisk_validate images/gpt-partition-types.img &&
 	sanitized_fdisk_sfdisk images/gpt-partition-types.img > gpt-partition-types.fdisk &&


### PR DESCRIPTION
The test for "gpt-partition-types" needs fdisk and sfdisk to be available. The buildtime tests fails if fdisk is not installed.