### PR TITLE
image-rauc: allow to specify an offset to skip input bytes

### DIFF
--- a/genimage.h
+++ b/genimage.h
@@ -45,6 +45,7 @@ struct partition {
 	cfg_bool_t no_automount;
 	cfg_bool_t fill;
 	const char *image;
+	off_t imageoffset;
 	struct list_head list;
 	int autoresize;
 	int in_partition_table;

--- a/test/misc.test
+++ b/test/misc.test
@@ -31,7 +31,7 @@ setup_rauc() {
 	mkdir input &&
 	cp -r "${testdir}"/rauc-openssl-ca input/ &&
 	echo "test" > input/rauc.content &&
-	echo "test2" > input/rauc2.content
+	echo "xtest2" > input/rauc2.content
 }
 
 exec_test_set_prereq rauc

--- a/test/rauc.config
+++ b/test/rauc.config
@@ -18,7 +18,10 @@ image test.raucb {
 }
 image test2.raucb {
 	rauc {
-		file data { image = "rauc2.content" }
+		file data {
+			image = "rauc2.content"
+			offset = 1
+		}
 		manifest = "
 			[update]
 			compatible=genimage-test


### PR DESCRIPTION
This is useful for barebox images on (at least) i.MX8 to be written to eMMC. There the first 32K of the image must be skipped.