### PR TITLE
README: Formalize signing off commits

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -671,3 +671,44 @@ To include a ``"foo.cfg"`` config file, use the following statement::
     include("foo.cfg")
 
 This allows to re-use, for example flash configuration files, across different image configurations.
+
+License and Developing
+======================
+
+To contribute to genimage please prepare a pull request on Github. To make
+it possible to include your modifications it's required that your code
+additions are licensed under the same terms as genimage itself. So you
+are required to agree to the following document:
+
+  Developer's Certificate of Origin 1.1
+
+  By making a contribution to this project, I certify that:
+
+  (a) The contribution was created in whole or in part by me and I
+      have the right to submit it under the open source license
+      indicated in the file; or
+
+  (b) The contribution is based upon previous work that, to the best
+      of my knowledge, is covered under an appropriate open source
+      license and I have the right under that license to submit that
+      work with modifications, whether created in whole or in part
+      by me, under the same open source license (unless I am
+      permitted to submit under a different license), as indicated
+      in the file; or
+
+  (c) The contribution was provided directly to me by some other
+      person who certified (a), (b) or (c) and I have not modified
+      it.
+
+  (d) I understand and agree that this project and the contribution
+      are public and that a record of the contribution (including all
+      personal information I submit with it, including my sign-off) is
+      maintained indefinitely and may be redistributed consistent with
+      this project or the open source license(s) involved.
+
+Your agreement is expressed by adding a sign-off line to each of your
+commits (e.g. using ``git commit -s``) looking as follows:
+
+        Signed-off-by: Random J Developer <random@developer.example.org>
+
+with your identity and email address matching the commit meta data.


### PR DESCRIPTION
The automatic checks for pull requests on Github include a check that fails if a Signed-off-by: line by the commiter is missing in any commit.

It's supposed to mean the "usual semantic also used in other open-source projects" but so far that is not spelled out anywhere.

So add a section to the README to make this explicit.