### PR TITLE
image-ext2: default to mke2fs

### DIFF
--- a/image-ext2.c
+++ b/image-ext2.c
@@ -209,7 +209,7 @@ static cfg_opt_t ext_opts[] = {
 	CFG_STR("features", NULL, CFGF_NONE),
 	CFG_STR("label", NULL, CFGF_NONE),
 	CFG_STR("fs-timestamp", NULL, CFGF_NONE),
-	CFG_BOOL("use-mke2fs", cfg_false, CFGF_NONE),
+	CFG_BOOL("use-mke2fs", cfg_true, CFGF_NONE),
 	CFG_STR("usage-type", NULL, CFGF_NONE),
 	CFG_STR("mke2fs-conf", NULL, CFGF_NONE),
 	CFG_STR("mke2fs_conf", NULL, CFGF_NONE),

--- a/test/ext2.config
+++ b/test/ext2.config
@@ -1,6 +1,7 @@
 image test.ext2 {
 	ext2 {
 		label = "ext2test"
+		use-mke2fs = false
 		fs-timestamp = "20000101000000"
 	}
 	size = 4M

--- a/test/ext2percent.config
+++ b/test/ext2percent.config
@@ -1,6 +1,7 @@
 image test.ext2 {
 	ext2 {
 		label = "ext2test"
+		use-mke2fs = false
 		fs-timestamp = "20000101000000"
 	}
 	size = 100%

--- a/test/ext3.config
+++ b/test/ext3.config
@@ -1,6 +1,7 @@
 image test.ext3 {
 	ext3 {
 		label = "ext3test"
+		use-mke2fs = false
 		fs-timestamp = "20000101000000"
 	}
 	size = 4M

--- a/test/ext4.config
+++ b/test/ext4.config
@@ -2,6 +2,7 @@ image test.ext4 {
 	ext4 {
 		label = "ext4test"
 		fs-timestamp = "20000101000000"
+		use-mke2fs = false
 	}
 	srcpath = "root.orig"
 	size = 4M


### PR DESCRIPTION
mke2fs is actually maintained and generated more modern filesystems. And it can create filesystems that support timestamps beyond 2038.