### PR TITLE
.gitignore: ignore libtool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ config.log
 config.status
 configure
 genimage
+libtool
 stamp-h1
 /test/*.log
 /test/*.trs


### PR DESCRIPTION
`libtool` is an auto-generated file. Hence, ignore it.