### PR TITLE
image-hd: gpt: add type GUID shortcut for barebox-env 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -144,6 +144,7 @@ Partition options:
 			* ``V``, ``lvm``: Linux LVM (e6d6d379-f507-44c2-a23c-238f2a3df928)
 			* ``F``, ``fat32``: FAT32 / Basic Data Partition (ebd0a0a2-b9e5-4433-87c0-68b6b72699c7)
 			* ``barebox-state`` (previously ``B``): Barebox State (4778ed65-bf42-45fa-9c5b-287a1dc4aab1)
+			* ``barebox-env``: Barebox Environment (6c3737f2-07f8-45d1-ad45-15d260aab24d)
 
                         Furthermore, for ``{arch}`` being one of ``alpha``,
                         ``arc``, ``arm``, ``arm64``, ``ia64``, ``loongarch64``,

--- a/README.rst
+++ b/README.rst
@@ -143,7 +143,7 @@ Partition options:
 			* ``R``, ``raid``: Linux RAID (a19d880f-05fc-4d3b-a006-743f0f84911e)
 			* ``V``, ``lvm``: Linux LVM (e6d6d379-f507-44c2-a23c-238f2a3df928)
 			* ``F``, ``fat32``: FAT32 / Basic Data Partition (ebd0a0a2-b9e5-4433-87c0-68b6b72699c7)
-			* ``B``, ``barebox-state``: Barebox State (4778ed65-bf42-45fa-9c5b-287a1dc4aab1)
+			* ``barebox-state`` (previously ``B``): Barebox State (4778ed65-bf42-45fa-9c5b-287a1dc4aab1)
 
                         Furthermore, for ``{arch}`` being one of ``alpha``,
                         ``arc``, ``arm``, ``arm64``, ``ia64``, ``loongarch64``,

--- a/image-hd.c
+++ b/image-hd.c
@@ -277,6 +277,7 @@ static const struct gpt_partition_type_shortcut_t gpt_partition_type_shortcuts[]
 	{ "F"                           , "ebd0a0a2-b9e5-4433-87c0-68b6b72699c7" },
 	{ "fat32"                       , "ebd0a0a2-b9e5-4433-87c0-68b6b72699c7" },
 	{ "barebox-state"               , "4778ed65-bf42-45fa-9c5b-287a1dc4aab1" },
+	{ "barebox-env"                 , "6c3737f2-07f8-45d1-ad45-15d260aab24d" },
 	/* Discoverable Partitions Specification GUID, see
 	 * https://uapi-group.org/specifications/specs/discoverable_partitions_specification/
 	 */

--- a/image-hd.c
+++ b/image-hd.c
@@ -276,7 +276,6 @@ static const struct gpt_partition_type_shortcut_t gpt_partition_type_shortcuts[]
 	{ "lvm"                         , "e6d6d379-f507-44c2-a23c-238f2a3df928" },
 	{ "F"                           , "ebd0a0a2-b9e5-4433-87c0-68b6b72699c7" },
 	{ "fat32"                       , "ebd0a0a2-b9e5-4433-87c0-68b6b72699c7" },
-	{ "B"                           , "4778ed65-bf42-45fa-9c5b-287a1dc4aab1" },
 	{ "barebox-state"               , "4778ed65-bf42-45fa-9c5b-287a1dc4aab1" },
 	/* Discoverable Partitions Specification GUID, see
 	 * https://uapi-group.org/specifications/specs/discoverable_partitions_specification/


### PR DESCRIPTION
barebox has been [documenting](https://github.com/barebox/barebox/commit/ef25a0ce960d) a dedicated GPT partition type GUID for
barebox environment partitions for a while and has started
making [actual](https://github.com/barebox/barebox/commit/9f868f78bc54
) [use](https://github.com/barebox/barebox/commit/287bd01a6a26) of it at runtime in its v2024.03.0 release.

Add a shorthand to make it easier to use.