### PR TITLE
image-erofs: introduce basic support for erofs

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -21,6 +21,7 @@ genimage_SOURCES = \
 	image-android-sparse.c \
 	image-cpio.c \
 	image-cramfs.c \
+	image-erofs.c \
 	image-ext2.c \
 	image-f2fs.c \
 	image-file.c \

--- a/README.rst
+++ b/README.rst
@@ -105,7 +105,7 @@ Here are all options for images:
 Additionally each image can have one of the following sections describing the
 type of the image:
 
-cpio, cramfs, ext2, ext3, ext4, file, flash, hdimage, iso, jffs2, qemu, squashfs,
+cpio, cramfs, erofs, ext2, ext3, ext4, file, flash, hdimage, iso, jffs2, qemu, squashfs,
 tar, ubi, ubifs, vfat.
 
 Partition options:
@@ -258,6 +258,14 @@ Generates cramfs images.
 Options:
 
 :extraargs:		Extra arguments passed to mkcramfs
+
+erofs
+******
+Generates erofs images.
+
+Options:
+
+:extraargs:		Extra arguments passed to mkfs.erofs.
 
 ext2, ext3, ext4
 ****************
@@ -655,6 +663,7 @@ variable.
 :mmd:		path to the mmd program (default mmd)
 :mkcramfs:	path to the mkcramfs program (default mkcramfs)
 :mkdosfs:	path to the mkdosfs program (default mkdosfs)
+:mkfserofs:	path to the mkfs.erofs program (default mkfs.erofs)
 :mkfsjffs2:	path to the mkfs.jffs2 program (default mkfs.jffs2)
 :mkfsubifs:	path to the mkfs.ubifs program (default mkfs.ubifs)
 :mksquashfs:	path to the mksquashfs program (default mksquashfs)

--- a/config.c
+++ b/config.c
@@ -399,6 +399,11 @@ static struct config opts[] = {
 		.env = "GENIMAGE_MKE2FS",
 		.def = "mke2fs",
 	}, {
+		.name = "mkfserofs",
+		.opt = CFG_STR("mkfserofs", NULL, CFGF_NONE),
+		.env = "GENIMAGE_MKFSEROFS",
+		.def = "mkfs.erofs",
+	}, {
 		.name = "mkfsjffs2",
 		.opt = CFG_STR("mkfsjffs2", NULL, CFGF_NONE),
 		.env = "GENIMAGE_MKFJFFS2",

--- a/genimage.c
+++ b/genimage.c
@@ -41,6 +41,7 @@ static struct image_handler *handlers[] = {
 	&android_sparse_handler,
 	&cpio_handler,
 	&cramfs_handler,
+	&erofs_handler,
 	&ext2_handler,
 	&ext3_handler,
 	&ext4_handler,

--- a/genimage.h
+++ b/genimage.h
@@ -107,6 +107,7 @@ struct flash_type *flash_type_get(const char *name);
 extern struct image_handler android_sparse_handler;
 extern struct image_handler cpio_handler;
 extern struct image_handler cramfs_handler;
+extern struct image_handler erofs_handler;
 extern struct image_handler ext2_handler;
 extern struct image_handler ext3_handler;
 extern struct image_handler ext4_handler;

--- a/image-erofs.c
+++ b/image-erofs.c
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2024 Sebastian Muxel <sebastian.muxel@entner-electronics.com>, Entner Electronics
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <confuse.h>
+#include "genimage.h"
+
+static int erofs_generate(struct image *image)
+{
+	int ret;
+	char *extraargs = cfg_getstr(image->imagesec, "extraargs");
+
+
+	ret = systemp(image, "%s  %s '%s' '%s'",
+			get_opt("mkfserofs"),
+			extraargs,
+			imageoutfile(image),
+			mountpath(image)
+	);
+
+	return ret;
+}
+
+static cfg_opt_t erofs_opts[] = {
+	CFG_STR("extraargs", "", CFGF_NONE),
+	CFG_END()
+};
+
+struct image_handler erofs_handler = {
+	.type = "erofs",
+	.generate = erofs_generate,
+	.opts = erofs_opts,
+};

--- a/test/erofs.config
+++ b/test/erofs.config
@@ -1,0 +1,5 @@
+image test.erofs {
+	erofs {
+	}
+	size = 4M
+}

--- a/test/filesystem.test
+++ b/test/filesystem.test
@@ -63,6 +63,14 @@ test_expect_success dd,mkdosfs,mcopy "vfat" "
 	check_filelist
 "
 
+exec_test_set_prereq mkfs.erofs
+exec_test_set_prereq fsck.erofs
+test_expect_success mkfs_erofs,fsck_erofs "erofs" "
+	run_genimage_root erofs.config test.erofs &&
+	fsck.erofs -p images/test.erofs | tee erofs.log &&
+	test_must_fail grep -q 'Filesystem was changed' erofs.log
+"
+
 test_done
 
 # vim: syntax=sh


### PR DESCRIPTION
 Erofs is a read-only file-system supported by the Linux Kernel since version 5.4.

This patchset adds basic support, a test & documentation for the filesystem.
I'm tempted to add some of the command-line options as dedicated config
nodes, but i'm unsure if it should be done.

- block-size: Defaults to the system page size, will likely be specified most of the time in real images
- compression: the latest release 1.7.1 supports lz4, lzma and lz4hc with various different options, specifying
these in extra-args will likely be easier.

I'm also not 100% sure about the testcase so i'm happy for comments