### PR TITLE
image-hd: add forced-primary flag for higher MBR layout flexibility

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -105,8 +105,14 @@ EXTRA_DIST += \
 	test/hdimage-fail5.config \
 	test/hdimage-fail6.config \
 	test/hdimage-fail7.config \
+	test/hdimage-fail8.config \
+	test/hdimage-fail9.config \
+	test/hdimage-fail10.config \
+	test/hdimage-fail11.config \
 	test/hdimage-nopart.config \
 	test/hdimage-nopart.hexdump \
+	test/hdimage-forced-primary.config \
+	test/hdimage-forced-primary.fdisk \
 	test/include-aaa.fdisk \
 	test/include-bbb.fdisk \
 	test/include-ccc.fdisk \

--- a/README.rst
+++ b/README.rst
@@ -131,6 +131,11 @@ Partition options:
 :bootable:		Boolean specifying whether to set the bootable flag.
 :in-partition-table:	Boolean specifying whether to include this partition in
 			the partition table. Defaults to true.
+:forced-primary:	Force this partition to be a primary partition in the
+			MBR partition table, useful when the extended partition should be
+			followed by primary partitions. If there are more partitions
+			defined after the first forced-primary, they must be also defined
+			as forced-primary. Defaults to false.
 :partition-uuid:	UUID string used by GPT partition tables to specify the partition
 			id. Defaults to a random value.
 :partition-type-uuid:	String used by GPT partition tables to specify the partition type.

--- a/genimage.c
+++ b/genimage.c
@@ -96,6 +96,7 @@ static cfg_opt_t partition_opts[] = {
 	CFG_STR("align", NULL, CFGF_NONE),
 	CFG_INT("partition-type", 0, CFGF_NONE),
 	CFG_BOOL("bootable", cfg_false, CFGF_NONE),
+	CFG_BOOL("forced-primary", cfg_false, CFGF_NONE),
 	CFG_BOOL("read-only", cfg_false, CFGF_NONE),
 	CFG_BOOL("hidden", cfg_false, CFGF_NONE),
 	CFG_BOOL("no-automount", cfg_false, CFGF_NONE),
@@ -396,6 +397,7 @@ static int parse_partitions(struct image *image, cfg_t *imagesec)
 		part->align = cfg_getint_suffix(partsec, "align");
 		part->partition_type = cfg_getint(partsec, "partition-type");
 		part->bootable = cfg_getbool(partsec, "bootable");
+		part->forced_primary = cfg_getbool(partsec, "forced-primary");
 		part->read_only = cfg_getbool(partsec, "read-only");
 		part->hidden = cfg_getbool(partsec, "hidden");
 		part->no_automount = cfg_getbool(partsec, "no-automount");

--- a/genimage.h
+++ b/genimage.h
@@ -39,7 +39,8 @@ struct partition {
 	unsigned long long align;
 	unsigned char partition_type;
 	cfg_bool_t bootable;
-	cfg_bool_t extended;
+	cfg_bool_t logical;
+	cfg_bool_t forced_primary;
 	cfg_bool_t read_only;
 	cfg_bool_t hidden;
 	cfg_bool_t no_automount;

--- a/test/hdimage-fail10.config
+++ b/test/hdimage-fail10.config
@@ -1,0 +1,33 @@
+image test.hdimage {
+	hdimage {
+		align = 1M
+		extended-partition = 3
+	}
+	partition primary1 {
+		image = "part1.img"
+		partition-type = 0x83
+	}
+	partition primary2 {
+		image = "part1.img"
+		partition-type = 0x83
+	}
+	partition extended1 {
+		image = "part1.img"
+		partition-type = 0x83
+	}
+	partition extended2 {
+		image = "part1.img"
+		partition-type = 0x83
+	}
+	partition primary3 {
+		image = "part1.img"
+		partition-type = 0x83
+		forced-primary = "yes"
+	}
+	partition primary4 {
+		image = "part1.img"
+		partition-type = 0x83
+		/* would be 5th primary partition */
+		forced-primary = "yes"
+	}
+}

--- a/test/hdimage-fail11.config
+++ b/test/hdimage-fail11.config
@@ -1,0 +1,32 @@
+image test.hdimage {
+	hdimage {
+		align = 1M
+		extended-partition = 1
+	}
+	partition extended1 {
+		image = "part1.img"
+		partition-type = 0x83
+	}
+	partition extended2 {
+		image = "part1.img"
+		partition-type = 0x83
+	}
+	partition extended3 {
+		image = "part1.img"
+		partition-type = 0x83
+	}
+	partition extended4 {
+		image = "part1.img"
+		partition-type = 0x83
+	}
+	partition primary2 {
+		image = "part1.img"
+		partition-type = 0x83
+		forced-primary = "yes"
+	}
+	partition extended5 {
+		image = "part1.img"
+		partition-type = 0x83
+		/* extended partition would overlap the forced-primary one */
+	}
+}

--- a/test/hdimage-fail8.config
+++ b/test/hdimage-fail8.config
@@ -1,0 +1,28 @@
+image test.hdimage {
+	hdimage {
+		align = 1M
+		extended-partition = 1
+	}
+	partition part1 {
+		image = "part1.img"
+		partition-type = 0x83
+		forced-primary = "yes"
+		/* forced-primary can be only used for partitions defined after the extended partition */
+	}
+	partition part2 {
+		image = "part1.img"
+		partition-type = 0x83
+	}
+	partition part3 {
+		image = "part1.img"
+		partition-type = 0x83
+	}
+	partition part4 {
+		image = "part1.img"
+		partition-type = 0x83
+	}
+	partition part5 {
+		image = "part1.img"
+		partition-type = 0x83
+	}
+}

--- a/test/hdimage-fail9.config
+++ b/test/hdimage-fail9.config
@@ -1,0 +1,27 @@
+image test.hdimage {
+	hdimage {
+		align = 1M
+	}
+	partition primary1 {
+		image = "part1.img"
+		partition-type = 0x83
+	}
+	partition primary2 {
+		image = "part1.img"
+		partition-type = 0x83
+	}
+	partition primary3 {
+		image = "part1.img"
+		partition-type = 0x83
+	}
+	partition primary4 {
+		image = "part1.img"
+		partition-type = 0x83
+	}
+	partition primary5 {
+		image = "part1.img"
+		partition-type = 0x83
+		/* part4 is implicitly extended -> too many primary entries */
+		forced-primary = "yes"
+	}
+}

--- a/test/hdimage-forced-primary.config
+++ b/test/hdimage-forced-primary.config
@@ -1,0 +1,47 @@
+image test.hdimage {
+	hdimage {
+		align = 1M
+		disk-signature = 0x12345678
+		extended-partition = 2
+	}
+	partition part1 {
+		image = "part1.img"
+		partition-type = 0xc
+		bootable = "yes"
+	}
+	/*
+	* partition 2 will be the extended partition entry
+	* partitions 3-4 will be primary partitions at the end
+	* partition 5 is first logical partition of the extended partition
+	*/
+	partition part5-logical {
+		image = "part1.img"
+		partition-type = 0x83
+	}
+	partition part6-logical {
+		image = "part2.img"
+		partition-type = 0x83
+	}
+	partition part7-logical {
+		image = "part1.img"
+		partition-type = 0x83
+	}
+	partition part8-logical {
+		image = "part2.img"
+		partition-type = 0x83
+	}
+	partition part9-logical {
+		image = "part1.img"
+		partition-type = 0x83
+	}
+	partition part3 {
+		image = "part1.img"
+		partition-type = 0x83
+		forced-primary = "yes"
+	}
+	partition part4 {
+		image = "part2.img"
+		partition-type = 0x82
+		forced-primary = "yes"
+	}
+}

--- a/test/hdimage-forced-primary.fdisk
+++ b/test/hdimage-forced-primary.fdisk
@@ -1,0 +1,10 @@
+Disk identifier: 0x12345678
+images/test.hdimage1:start=2048,size=2048,type=c,bootable
+images/test.hdimage2:start=4096,size=20480,type=f
+images/test.hdimage3:start=24576,size=2048,type=83
+images/test.hdimage4:start=26624,size=2048,type=82
+images/test.hdimage5:start=6144,size=2048,type=83
+images/test.hdimage6:start=10240,size=2048,type=83
+images/test.hdimage7:start=14336,size=2048,type=83
+images/test.hdimage8:start=18432,size=2048,type=83
+images/test.hdimage9:start=22528,size=2048,type=83

--- a/test/hdimage.test
+++ b/test/hdimage.test
@@ -96,7 +96,11 @@ test_expect_success "hdimage syntax" "
 	test_must_fail run_genimage hdimage-fail4.config &&
 	test_must_fail run_genimage hdimage-fail5.config &&
 	test_must_fail run_genimage hdimage-fail6.config &&
-	test_must_fail run_genimage hdimage-fail7.config
+	test_must_fail run_genimage hdimage-fail7.config &&
+	test_must_fail run_genimage hdimage-fail8.config &&
+	test_must_fail run_genimage hdimage-fail9.config &&
+	test_must_fail run_genimage hdimage-fail10.config &&
+	test_must_fail run_genimage hdimage-fail11.config
 "
 
 setup_gpt_files() {
@@ -161,6 +165,14 @@ test_expect_success "hdimage no-partition" "
 	run_genimage hdimage-nopart.config &&
 	hexdump -C images/test.hdimage > 'hdimage-nopart.hexdump' &&
 	test_cmp 'hdimage-nopart.hexdump' '${testdir}/hdimage-nopart.hexdump'
+"
+
+test_expect_success "hdimage forced-primary" "
+  setup_test_images &&
+	run_genimage hdimage-forced-primary.config &&
+	sfdisk_validate images/test.hdimage &&
+	sanitized_fdisk_sfdisk images/test.hdimage > hdimage.fdisk &&
+	test_cmp '${testdir}/hdimage-forced-primary.fdisk' hdimage.fdisk
 "
 
 test_done


### PR DESCRIPTION
The current limitation of Genimage is that it is not able to create MBR images that have primary partitions that start after a logical partition. This can be useful for images that can be later resized based on the actual device size - for this operation the partition must be at the end of the device, and if it is present in a logical partition, it must be resized first, making it a two-step process.

This commit adds the "forced-primary" flag which can be used to indicate that the partition should be put into the disk's MBR instead of creating another logical partition. Validation ensures that this syntax allows to create such partitions only after an existing logical partition, and that the maximum number of MBR entries woudn't be exceeded by doing so.

Test cases for valid and invalid configuiration has been added. Also added few more details in the debug print to make it more obvious how the MBR/EBR layout looks like.