### PR TITLE
image-ext2: use single quotes around label for mke2fs

### DIFF
--- a/image-ext2.c
+++ b/image-ext2.c
@@ -83,13 +83,16 @@ static int ext2_generate_mke2fs(struct image *image)
 	if (ret < 0)
 		return ret;
 
-	return systemp(image, "%s%s -t %s%s -I 256 -E 'root_owner=%s,%s'%s %s%s%s %s %s%s %s%s%s '%s' %lldk",
+	return systemp(image, "%s%s -t %s%s -I 256 -E 'root_owner=%s,%s'%s %s%s%s %s %s%s%s %s%s%s '%s' %lldk",
 			ext->conf_env, get_opt("mke2fs"), image->handler->type,
 			ext->usage_type_args, root_owner, options, ext->size_features,
 			image->empty ? "" : "-d '",
 			image->empty ? "" : mountpath(image),
 			image->empty ? "" : "'",
-			extraargs, label ? "-L " : "", label ? label : "",
+			extraargs,
+			label ? "-L '" : "",
+			label ? label : "",
+			label ? "'" : "",
 			features ? "-O '" : "",
 			features ? features : "",
 			features ? "'" : "",


### PR DESCRIPTION
When the volume label is set using tune2fs, the parameter is wrapped in single quotes, so do the same when the label is set using mke2fs.  This allows the label to contain spaces and other special characters (except for single quotes!).