### PR TITLE
run_genimage_impl: abort for missing config file

### DIFF
--- a/test/test-setup.sh
+++ b/test/test-setup.sh
@@ -26,6 +26,10 @@ setup_data() {
 }
 
 run_genimage_impl() {
+	if [ ! -e "${1}" ]; then
+		echo "ERROR: genimage config file '${1}' missing!"
+		return 130
+	fi
 	if [ "$verbose" = "t" ]; then
 		vargs="--loglevel=3"
 	fi


### PR DESCRIPTION
Otherwise, a missing config file is not detected for tests that are expected to fail.