### PR TITLE
image-android-sparse: initialize chunk_header

### DIFF
--- a/image-android-sparse.c
+++ b/image-android-sparse.c
@@ -114,7 +114,7 @@ static int android_sparse_generate(struct image *image)
 	struct image *inimage;
 	const char *infile;
 	struct sparse_header header;
-	struct sparse_chunk_header chunk_header;
+	struct sparse_chunk_header chunk_header = {};
 	struct extent *extents = NULL;
 	size_t extent_count, extent, block_count, block;
 	int in_fd = -1, out_fd = -1, ret;


### PR DESCRIPTION
It contains a reserved field that remains uninitialized otherwise and is written to the output file.