### PR TITLE
util.c: add fsync_close() helper, use where appropriate

### DIFF
--- a/test/hdimage.test
+++ b/test/hdimage.test
@@ -34,7 +34,7 @@ test_expect_success fdisk,sfdisk "hdimage" "
 	test_cmp '${testdir}/hdimage.fdisk' hdimage.fdisk &&
 	check_size images/test.hdimage-2 11539968 &&
 	sfdisk_validate images/test.hdimage-2 &&
-	check_disk_usage_range images/test.hdimage-2 61290 65376 &&
+	check_disk_usage_range images/test.hdimage-2 61290 65536 &&
 	sanitized_fdisk_sfdisk images/test.hdimage-2 > hdimage.fdisk-2 &&
 	test_cmp '${testdir}/hdimage.fdisk-2' hdimage.fdisk-2
 "


### PR DESCRIPTION
Using genimage directly on an eMMC on target, I'm seeing that the BLKRRPART ioctl fails with EBUSY, presumably because there's still lots of data in flight, and then subsequent parts of my bootstrap procedure fail because the expected partitions can't be found.

Whenever we've written some data, we really should ensure that all data has hit the disk before proceeding, and close() itself is not synchronous.

Add a fsync_close() helper that does exactly what it says on the tin. Use that wherever we close an fd that has been open for writing and actually written to (i.e., no point in doing that in the reload_partitions() function).

Currently, the return value of these close() calls are ignored, so at least for now continue to do that, but at least we do see an error message in case something went wrong.