### PR TITLE
image-hd: set the first usable lba correctly

### DIFF
--- a/image-hd.c
+++ b/image-hd.c
@@ -109,6 +109,26 @@ ct_assert(sizeof(struct gpt_partition_entry) == 128);
 #define GPT_PE_FLAG_HIDDEN	(1ULL << 62)
 #define GPT_PE_FLAG_NO_AUTO	(1ULL << 63)
 
+static unsigned long long roundup(unsigned long long value, unsigned long long align)
+{
+	return ((value - 1)/align + 1) * align;
+}
+
+static unsigned long long rounddown(unsigned long long value, unsigned long long align)
+{
+	return value - (value % align);
+}
+
+static unsigned long long min_ull(unsigned long long x, unsigned long long y)
+{
+	return x < y ? x : y;
+}
+
+static unsigned long long max_ull(unsigned long long x, unsigned long long y)
+{
+	return x > y ? x : y;
+}
+
 static unsigned long long partition_end(const struct partition *part)
 {
 	return part->offset + part->size;
@@ -657,26 +677,6 @@ static int hdimage_generate(struct image *image)
 		return reload_partitions(image);
 
 	return 0;
-}
-
-static unsigned long long roundup(unsigned long long value, unsigned long long align)
-{
-	return ((value - 1)/align + 1) * align;
-}
-
-static unsigned long long rounddown(unsigned long long value, unsigned long long align)
-{
-	return value - (value % align);
-}
-
-static unsigned long long min_ull(unsigned long long x, unsigned long long y)
-{
-	return x < y ? x : y;
-}
-
-static unsigned long long max_ull(unsigned long long x, unsigned long long y)
-{
-	return x > y ? x : y;
 }
 
 static bool image_has_hole_covering(const char *image,


### PR DESCRIPTION
Before this, the begining of the first partition was used. This leaves
some unusable space between the partition table and the first partition
and causes some Windows versions to alter the GPT.
    
So set the first usable lba correctly: Set it to the first lba after the
last non-partition data before the first partition.
This will either be directly behind the GPT entry array or, for example
after a bootloader that is placed between the partition table and the
first partition.

Fixes: #262