### PR TITLE
hd-image: add support for specifying byte value used for filling

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -122,7 +122,8 @@ Partition options:
 :image:			The image file this partition shall be filled with
 :fill:			Boolean specifying that all bytes of the partition should be
 			explicitly initialized. Any bytes beyond the size of the specified
-			image will be set to 0.
+			image will be set to ``fill-value``.
+:fill-value:		Byte value used when ``fill`` is true, defaults to 0.
 :autoresize:		Boolean specifying that the partition should be resized
 			automatically. For UBI volumes this means that the
 			``autoresize`` flag is set. Only one volume can have this flag.

--- a/genimage.c
+++ b/genimage.c
@@ -102,6 +102,7 @@ static cfg_opt_t partition_opts[] = {
 	CFG_BOOL("hidden", cfg_false, CFGF_NONE),
 	CFG_BOOL("no-automount", cfg_false, CFGF_NONE),
 	CFG_BOOL("fill", cfg_false, CFGF_NONE),
+	CFG_INT("fill-value", 0, CFGF_NONE),
 	CFG_STR("image", NULL, CFGF_NONE),
 	CFG_STR_LIST("holes", NULL, CFGF_NONE),
 	CFG_BOOL("autoresize", 0, CFGF_NONE),
@@ -403,6 +404,7 @@ static int parse_partitions(struct image *image, cfg_t *imagesec)
 		part->hidden = cfg_getbool(partsec, "hidden");
 		part->no_automount = cfg_getbool(partsec, "no-automount");
 		part->fill = cfg_getbool(partsec, "fill");
+		part->fill_value = cfg_getint(partsec, "fill-value");
 		part->image = cfg_getstr(partsec, "image");
 		part->autoresize = cfg_getbool(partsec, "autoresize");
 		part->in_partition_table = cfg_getbool(partsec, "in-partition-table");

--- a/genimage.h
+++ b/genimage.h
@@ -45,6 +45,7 @@ struct partition {
 	cfg_bool_t hidden;
 	cfg_bool_t no_automount;
 	cfg_bool_t fill;
+	unsigned char fill_value;
 	const char *image;
 	off_t imageoffset;
 	struct list_head list;

--- a/image-hd.c
+++ b/image-hd.c
@@ -609,7 +609,8 @@ static int hdimage_generate(struct image *image)
 			return -E2BIG;
 		}
 
-		ret = insert_image(image, child, part->fill ? part->size : child->size, part->offset, 0);
+		ret = insert_image(image, child, part->fill ? part->size : child->size,
+				   part->offset, part->fill_value);
 		if (ret) {
 			image_error(image, "failed to write image partition '%s'\n",
 					part->name);


### PR DESCRIPTION
Today I was fooled by the combination of (1) util.c being quite clever/aggressive with respect to creating sparse images and avoiding writing zeroes explicitly and (2) using bmaptool to populate an SD card, thus being aware of unwritten regions of the image.

Specifically, I had a U-Boot environment partition where I now set "fill = true", so that any trace of the previous environment should be gone, and U-Boot on first boot should just use its default/static environment.

But that was not what I observed: After writing the sd card, the U-Boot partition still has its old content, meaning that the new U-Boot ended up using a completely wrong environment.

In order to be sure that such a partition is definitely overwritten, allow specifiyng the byte value used for filling. Any non-zero value should work fine.

Alternatively/additionally, we could consider relaxing the sparseness, so that, say, the first 4096 bytes of the padding are always explicitly written. But I don't know if bmaptool is so "smart" that it checks whether it has a full 4096 bytes of zeroes and then turning that into a sparse write anyway.