### PR TITLE
Add options to explicitly fill holes

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -146,6 +146,7 @@ EXTRA_DIST += \
 	test/rauc.config \
 	test/sharness.sh \
 	test/sparse.config \
+	test/sparse-fill.config \
 	test/squashfs.config \
 	test/tar.config \
 	test/test.raucb.info.1 \

--- a/Makefile.am
+++ b/Makefile.am
@@ -121,6 +121,7 @@ EXTRA_DIST += \
 	test/hdimage-nopart.hexdump \
 	test/hdimage-forced-primary.config \
 	test/hdimage-forced-primary.fdisk \
+	test/hdimage-sparse.config \
 	test/include-aaa.fdisk \
 	test/include-bbb.fdisk \
 	test/include-ccc.fdisk \

--- a/README.rst
+++ b/README.rst
@@ -123,6 +123,12 @@ Partition options:
 :fill:			Boolean specifying that all bytes of the partition should be
 			explicitly initialized. Any bytes beyond the size of the specified
 			image will be set to 0.
+:sparse:		If true (the default) 'holes' in the input images are preserved
+			and the remaining free space in the partition is also a 'hole'.
+			If false, the 'holes' in the input image are explicitly
+			filled with zeros when the image is copied. If ``fill``
+			is specified as well then the remaining free space is
+			also filled with zeros.
 :autoresize:		Boolean specifying that the partition should be resized
 			automatically. For UBI volumes this means that the
 			``autoresize`` flag is set. Only one volume can have this flag.

--- a/README.rst
+++ b/README.rst
@@ -251,6 +251,8 @@ Options:
 :block-size:		The granularity that the sparse image uses to
 			find "don't care" or "fill" blocks. The supported
 			block sizes depend on the user. The default is 4k.
+:fill-holes:		If enabled, 'holes' are filled with zero instead of
+			"don't care". Disabled by default.
 
 cpio
 ****

--- a/genimage.c
+++ b/genimage.c
@@ -103,6 +103,7 @@ static cfg_opt_t partition_opts[] = {
 	CFG_BOOL("hidden", cfg_false, CFGF_NONE),
 	CFG_BOOL("no-automount", cfg_false, CFGF_NONE),
 	CFG_BOOL("fill", cfg_false, CFGF_NONE),
+	CFG_BOOL("sparse", cfg_true, CFGF_NONE),
 	CFG_STR("image", NULL, CFGF_NONE),
 	CFG_STR_LIST("holes", NULL, CFGF_NONE),
 	CFG_BOOL("autoresize", 0, CFGF_NONE),
@@ -404,6 +405,7 @@ static int parse_partitions(struct image *image, cfg_t *imagesec)
 		part->hidden = cfg_getbool(partsec, "hidden");
 		part->no_automount = cfg_getbool(partsec, "no-automount");
 		part->fill = cfg_getbool(partsec, "fill");
+		part->sparse = cfg_getbool(partsec, "sparse");
 		part->image = cfg_getstr(partsec, "image");
 		part->autoresize = cfg_getbool(partsec, "autoresize");
 		part->in_partition_table = cfg_getbool(partsec, "in-partition-table");

--- a/genimage.h
+++ b/genimage.h
@@ -50,6 +50,7 @@ struct partition {
 	cfg_bool_t hidden;
 	cfg_bool_t no_automount;
 	cfg_bool_t fill;
+	cfg_bool_t sparse;
 	const char *image;
 	off_t imageoffset;
 	struct list_head list;
@@ -182,7 +183,7 @@ int block_device_size(struct image *image, const char *blkdev,
 int prepare_image(struct image *image, unsigned long long size);
 int insert_image(struct image *image, struct image *sub,
 		 unsigned long long size, unsigned long long offset,
-		 unsigned char byte);
+		 unsigned char byte, cfg_bool_t sparse);
 int insert_data(struct image *image, const void *data, const char *outfile,
 		size_t size, unsigned long long offset);
 int extend_file(struct image *image, size_t size);

--- a/genimage.h
+++ b/genimage.h
@@ -175,6 +175,8 @@ struct extent {
 };
 
 int open_file(struct image *image, const char *filename, int extra_flags);
+int whole_file_exent(size_t size, struct extent **extents,
+		     size_t *extent_count);
 int map_file_extents(struct image *image, const char *filename, int fd,
 		     size_t size, struct extent **extents, size_t *extent_count);
 int is_block_device(const char *filename);

--- a/image-flash.c
+++ b/image-flash.c
@@ -46,7 +46,7 @@ static int flash_generate(struct image *image)
 			   part->name, part->size, part->offset);
 
 		if (part->offset > end) {
-			ret = insert_image(image, NULL, part->offset - end, end, 0xFF);
+			ret = insert_image(image, NULL, part->offset - end, end, 0xFF, cfg_false);
 			if (ret) {
 				image_error(image, "failed to pad image to size %lld\n",
 					    part->offset);
@@ -57,7 +57,7 @@ static int flash_generate(struct image *image)
 		if (part->image)
 			child = image_get(part->image);
 
-		ret = insert_image(image, child, part->size, part->offset, 0xFF);
+		ret = insert_image(image, child, part->size, part->offset, 0xFF, cfg_false);
 		if (ret) {
 			image_error(image, "failed to write image partition '%s'\n",
 				    part->name);

--- a/image-hd.c
+++ b/image-hd.c
@@ -623,7 +623,8 @@ static int hdimage_generate(struct image *image)
 			return -E2BIG;
 		}
 
-		ret = insert_image(image, child, part->fill ? part->size : child->size, part->offset, 0);
+		ret = insert_image(image, child, part->fill ? part->size : child->size,
+				   part->offset, 0, part->sparse);
 		if (ret) {
 			image_error(image, "failed to write image partition '%s'\n",
 				    part->name);

--- a/image-mdraid.c
+++ b/image-mdraid.c
@@ -375,7 +375,7 @@ static int mdraid_generate(struct image *image)
 	}
 	/* Write data */
 	if (md->img_data) {
-		ret = insert_image(image, md->img_data, md->img_data->size, DATA_OFFSET_BYTES, 0);
+		ret = insert_image(image, md->img_data, md->img_data->size, DATA_OFFSET_BYTES, 0, cfg_true);
 		if (ret)
 			return ret;
 	}

--- a/test/ext.test
+++ b/test/ext.test
@@ -109,8 +109,6 @@ test_expect_success genext2fs,e2fsck "ext4" "
 	check_ext images/test.ext4 ext4test 4194304 genext2fs
 "
 
-# make sure mke2fs supports '-d root-directory'
-[ "$(mke2fs |& sed -n 's/.*\(-d \).*/\1/p')" = "-d " ] && test_set_prereq mke2fs
 test_expect_success mke2fs,e2fsck "mke2fs" "
 	run_genimage_root mke2fs.config mke2fs.ext4 &&
 	check_ext images/mke2fs.ext4 mke2fs 33554432 mke2fs

--- a/test/hdimage-sparse.config
+++ b/test/hdimage-sparse.config
@@ -1,0 +1,53 @@
+image test.ext4 {
+	ext4 {
+		label = "mke2fs"
+		fs-timestamp = "20000101000000"
+		use-mke2fs = true
+		mke2fs-conf = "mke2fs.conf"
+		extraargs = "-U 12345678-1234-1234-1234-1234567890ab -E quotatype="
+		features = "^resize_inode,quota"
+	}
+	size = 32M
+}
+
+image test.hdimage {
+	hdimage {
+		align = 1M
+		fill = true
+		disk-signature = 0x12345678
+	}
+	partition part1 {
+		image = "part1.img"
+		size = 1M
+		partition-type = 0x83
+	}
+	partition part2 {
+		image = "test.ext4"
+		partition-type = 0x83
+		sparse = false
+	}
+	partition part3 {
+		image = "part1.img"
+		size = 1M
+		partition-type = 0x83
+	}
+	partition part4 {
+		image = "part2.img"
+		size = 1M
+		partition-type = 0x83
+		fill = true
+		sparse = false
+	}
+	partition part5 {
+		image = "part1.img"
+		size = 1M
+		partition-type = 0x83
+	}
+	partition part6 {
+		image = "part2.img"
+		size = 1M
+		partition-type = 0x83
+		fill = true
+		sparse = false
+	}
+}

--- a/test/hdimage.test
+++ b/test/hdimage.test
@@ -176,6 +176,14 @@ test_expect_success sfdisk "hdimage forced-primary" "
 	test_cmp '${testdir}/hdimage-forced-primary.fdisk' hdimage.fdisk
 "
 
+test_expect_success fdisk,sfdisk,mke2fs "hdimage sparse" "
+	setup_test_images &&
+	run_genimage_root hdimage-sparse.config test.hdimage &&
+	check_size images/test.hdimage 42991616 &&
+	sfdisk_validate images/test.hdimage &&
+	check_disk_usage_range images/test.hdimage 34000000 37000000
+"
+
 test_done
 
 # vim: syntax=sh

--- a/test/misc.test
+++ b/test/misc.test
@@ -93,6 +93,17 @@ test_expect_success simg2img "android-sparse" "
 	simg2img images/test.sparse images/test.hdimage &&
 	simg2img images/interleaved.sparse input/interleaved &&
 	simg2img images/not-aligned.sparse input/not-aligned &&
+	md5sum -c md5sum &&
+
+	run_genimage sparse-fill.config &&
+	# simg2img will expand the partial block
+	truncate --size=12k input/not-aligned
+	md5sum images/test.hdimage input/interleaved input/not-aligned > md5sum &&
+	rm images/test.hdimage input/interleaved input/not-aligned &&
+	check_size_range images/interleaved.sparse 9732464 9732636 &&
+	simg2img images/test.sparse images/test.hdimage &&
+	simg2img images/interleaved.sparse input/interleaved &&
+	simg2img images/not-aligned.sparse input/not-aligned &&
 	md5sum -c md5sum
 "
 

--- a/test/sparse-fill.config
+++ b/test/sparse-fill.config
@@ -1,0 +1,42 @@
+image test.hdimage {
+	hdimage {
+		align = 1M
+		partition-table-type = "gpt"
+		disk-uuid = "afcfea87-e41a-40e0-85ae-295c60773c7a"
+	}
+	partition part1 {
+		image = "part1.img"
+		size = 10M
+		partition-uuid = "92762261-e854-45c1-b4c9-fc5e752034ab"
+	}
+	partition part2 {
+		image = "part2.img"
+		size = 10M
+		partition-type-uuid = "L"
+		partition-uuid = "41061242-1d5a-4657-892d-fcc1fdb11a6c"
+	}
+	size = 22M
+}
+
+image test.sparse {
+	android-sparse {
+		image = test.hdimage
+		fill-holes = true
+	}
+}
+
+image interleaved.sparse {
+	android-sparse {
+		image = interleaved
+		block-size = 32k
+		fill-holes = true
+	}
+}
+
+image not-aligned.sparse {
+	android-sparse {
+		image = not-aligned
+		block-size = 4k
+		fill-holes = true
+	}
+}

--- a/test/test-setup.sh
+++ b/test/test-setup.sh
@@ -119,3 +119,5 @@ setup_data
 
 sfdisk -h | grep -q gpt && test_set_prereq sfdisk-gpt
 fdisk -h | grep -q gpt && test_set_prereq fdisk-gpt
+# make sure mke2fs supports '-d root-directory'
+[ "$(mke2fs |& sed -n 's/.*\(-d \).*/\1/p')" = "-d " ] && test_set_prereq mke2fs

--- a/util.c
+++ b/util.c
@@ -398,8 +398,8 @@ int open_file(struct image *image, const char *filename, int extra_flags)
 }
 
 /* Build a file extent covering the whole file */
-static int whole_file_exent(size_t size, struct extent **extents,
-			    size_t *extent_count)
+int whole_file_exent(size_t size, struct extent **extents,
+		     size_t *extent_count)
 {
 	*extents = xzalloc(sizeof(struct extent));
 	(*extents)[0].start = 0;


### PR DESCRIPTION
In some cases, preserving 'holes' can be undesirably. So add some options to fill the holes instead:

- `sparse` for partitions, to make the decision on a per partition basis
- `fill-holes` for android sparse images to convert all holes into fill areas