### PR TITLE
Add missing space in error messages

### DIFF
--- a/image-flash.c
+++ b/image-flash.c
@@ -104,7 +104,7 @@ static int flash_setup(struct image *image, cfg_t *cfg)
 			return -EINVAL;
 		}
 		if (part->offset % image->flash_type->pebsize) {
-			image_error(image, "part %s offset (%lld) must be a"
+			image_error(image, "part %s offset (%lld) must be a "
 					   "multiple of erase block size (%i bytes)\n",
 				    part->name, part->offset, image->flash_type->pebsize);
 			return -EINVAL;

--- a/image-hd.c
+++ b/image-hd.c
@@ -1122,7 +1122,7 @@ static int hdimage_setup(struct image *image, cfg_t *cfg)
 		}
 
 		if (part->offset % part->align) {
-			image_error(image, "part %s offset (%lld) must be a"
+			image_error(image, "part %s offset (%lld) must be a "
 					   "multiple of %lld bytes\n",
 				    part->name, part->offset, part->align);
 			return -EINVAL;


### PR DESCRIPTION
Add the missing space in messages such as:
"offset (...) must be amultiple of ... bytes"