### PR TITLE
MDRAID: Set default homehost to 'any' and mention that in docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -495,7 +495,9 @@ Generates MD RAID images.
 
 Options:
 
-:label:			Text name of array (optional) eg: localhost:42
+:label:			Optional hostname and name of array separated by colon, eg: ``any:42``.
+			Special hostname ``any`` can be used to make array local to machine with any hostname.
+			Name will be used by OS to name ``/dev/md/*`` device (as long as the hostname matches).
 :level:			RAID level, currently only level 1 (default) is supported
 :devices:		Number of devices in array (default 1)
 :role:			0 based index of this image in whole array. (autoassigned by default)

--- a/image-mdraid.c
+++ b/image-mdraid.c
@@ -466,7 +466,7 @@ static int mdraid_setup(struct image *image, cfg_t *cfg)
 }
 
 static cfg_opt_t mdraid_opts[] = {
-	CFG_STR("label", "localhost:42", CFGF_NONE),
+	CFG_STR("label", "any:42", CFGF_NONE),
 	CFG_INT("level", 1, CFGF_NONE),
 	CFG_INT("devices", 1, CFGF_NONE),
 	CFG_INT("role", -1, CFGF_NONE),


### PR DESCRIPTION
I've noticed this thing in mdadm manpage and figured that it would be better option than 'localhost'.