### PR TITLE
image-fip: check size of generated image

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -79,6 +79,7 @@ EXTRA_DIST += \
 	test/mdraid.config \
 	test/btrfs.config \
 	test/fip.config \
+	test/fip-size.config \
 	test/fit.its \
 	test/fit.config \
 	test/flash-types.config \

--- a/image-fip.c
+++ b/image-fip.c
@@ -19,6 +19,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <errno.h>
+#include <sys/stat.h>
 
 #include "genimage.h"
 
@@ -42,6 +43,16 @@ static int fip_generate(struct image *image)
 		      args, extraargs, imageoutfile(image));
 
 	free(args);
+
+	if (ret == 0) {
+		struct stat statbuf;
+		ret = stat(imageoutfile(image), &statbuf);
+
+		if (ret)
+			return ret;
+
+		image->size = statbuf.st_size;
+	}
 
 	return ret;
 }

--- a/test/fip-size.config
+++ b/test/fip-size.config
@@ -1,0 +1,16 @@
+image test.fip {
+	fip {
+		extraargs = "--align 64"
+		fw-config = "part1.img"
+		tos-fw = { "part2.img", "part1.img" }
+		/* will be about 12k in size */
+	}
+}
+
+image test.hdimage {
+	hdimage {}
+	partition part1 {
+		image = test.fip
+		size = 512  /* too small for fip image */
+	}
+}

--- a/test/misc.test
+++ b/test/misc.test
@@ -115,6 +115,11 @@ test_expect_success fiptool "fip" "
 	fiptool info images/test.fip
 "
 
+test_expect_success fiptool "fip-size" "
+	setup_test_images &&
+	test_must_fail run_genimage fip-size.config test.fip
+"
+
 exec_test_set_prereq mdadm
 test_expect_success mdadm "mdraid" "
 	run_genimage_root mdraid.config test.mdraid-a &&


### PR DESCRIPTION
Until now, the `image->size` of the generated FIP image was 0, which meant that hdimage_generate() did not check if the image fits into the available space of a partition, which could result in an incomplete FIP image if the image was too large and would be overwritten by contents of later partitions. Determine the size of the generated FIP image with a stat() call, so that hdimage_generate() can error out if it does not fit, e.g. in our test case:

```
INFO: hdimage(test.hdimage): adding primary partition 'part1' (in MBR) from 'test.fip' ...
ERROR: hdimage(test.hdimage): part part1 size (512) too small for test.fip (12992)
```