### PR TITLE
image-erofs: introduce basic support for erofs

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -21,6 +21,7 @@ genimage_SOURCES = \
 	image-android-sparse.c \
 	image-cpio.c \
 	image-cramfs.c \
+	image-erofs.c \
 	image-ext2.c \
 	image-f2fs.c \
 	image-mdraid.c \

--- a/Makefile.am
+++ b/Makefile.am
@@ -58,6 +58,7 @@ EXTRA_DIST += \
 	test/cpio.config \
 	test/cramfs.config \
 	test/erofs.config \
+	test/erofs.dump \
 	test/exec-check.sh \
 	test/exec-fail.config \
 	test/exec.config \

--- a/Makefile.am
+++ b/Makefile.am
@@ -57,6 +57,7 @@ EXTRA_DIST += \
 	test/test-setup.sh \
 	test/cpio.config \
 	test/cramfs.config \
+	test/erofs.config \
 	test/exec-check.sh \
 	test/exec-fail.config \
 	test/exec.config \

--- a/README.rst
+++ b/README.rst
@@ -105,7 +105,7 @@ Here are all options for images:
 Additionally each image can have one of the following sections describing the
 type of the image:
 
-cpio, cramfs, ext2, ext3, ext4, f2fs, file, flash, hdimage, iso,
+cpio, cramfs, erofs, ext2, ext3, ext4, f2fs, file, flash, hdimage, iso,
 jffs2, mdraid, qemu, squashfs, tar, ubi, ubifs, vfat.
 
 Partition options:
@@ -278,6 +278,14 @@ Generates cramfs images.
 Options:
 
 :extraargs:		Extra arguments passed to mkcramfs
+
+erofs
+******
+Generates erofs images.
+
+Options:
+
+:extraargs:		Extra arguments passed to mkfs.erofs.
 
 ext2, ext3, ext4
 ****************
@@ -743,6 +751,7 @@ variable.
 :mmd:		path to the mmd program (default mmd)
 :mkcramfs:	path to the mkcramfs program (default mkcramfs)
 :mkdosfs:	path to the mkdosfs program (default mkdosfs)
+:mkfserofs:	path to the mkfs.erofs program (default mkfs.erofs)
 :mkfsf2fs:	path to the mkfs.f2fs program (default mkfs.f2fs)
 :mkfsjffs2:	path to the mkfs.jffs2 program (default mkfs.jffs2)
 :mkfsubifs:	path to the mkfs.ubifs program (default mkfs.ubifs)

--- a/config.c
+++ b/config.c
@@ -417,6 +417,12 @@ static struct config opts[] = {
 		.def = "mke2fs",
 	},
 	{
+		.name = "mkfserofs",
+		.opt = CFG_STR("mkfserofs", NULL, CFGF_NONE),
+		.env = "GENIMAGE_MKFSEROFS",
+		.def = "mkfs.erofs",
+	},
+	{
 		.name = "mkfsjffs2",
 		.opt = CFG_STR("mkfsjffs2", NULL, CFGF_NONE),
 		.env = "GENIMAGE_MKFJFFS2",

--- a/genimage.c
+++ b/genimage.c
@@ -41,6 +41,7 @@ static struct image_handler *handlers[] = {
 	&android_sparse_handler,
 	&cpio_handler,
 	&cramfs_handler,
+	&erofs_handler,
 	&ext2_handler,
 	&ext3_handler,
 	&ext4_handler,

--- a/genimage.h
+++ b/genimage.h
@@ -114,6 +114,7 @@ struct flash_type *flash_type_get(const char *name);
 extern struct image_handler android_sparse_handler;
 extern struct image_handler cpio_handler;
 extern struct image_handler cramfs_handler;
+extern struct image_handler erofs_handler;
 extern struct image_handler ext2_handler;
 extern struct image_handler ext3_handler;
 extern struct image_handler ext4_handler;

--- a/image-erofs.c
+++ b/image-erofs.c
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2024 Sebastian Muxel <sebastian.muxel@entner-electronics.com>, Entner Electronics
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <confuse.h>
+#include "genimage.h"
+
+static int erofs_generate(struct image *image)
+{
+	int ret;
+	char *extraargs = cfg_getstr(image->imagesec, "extraargs");
+
+	ret = systemp(image, "%s  %s '%s' '%s'",
+		      get_opt("mkfserofs"),
+		      extraargs,
+		      imageoutfile(image),
+		      mountpath(image));
+
+	return ret;
+}
+
+static cfg_opt_t erofs_opts[] = {
+	CFG_STR("extraargs", "", CFGF_NONE),
+	CFG_END()
+};
+
+struct image_handler erofs_handler = {
+	.type = "erofs",
+	.generate = erofs_generate,
+	.opts = erofs_opts,
+};

--- a/image-erofs.c
+++ b/image-erofs.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2024 Sebastian Muxel <sebastian.muxel@entner-electronics.com>, Entner Electronics
+ *           (c) 2025 Michael Olbrich <m.olbrich@pengutronix.de>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2
@@ -15,15 +16,30 @@
  */
 
 #include <confuse.h>
+
+#include <errno.h>
+#include <string.h>
+
 #include "genimage.h"
+
+struct erofs {
+	const char *label;
+};
 
 static int erofs_generate(struct image *image)
 {
-	int ret;
+	struct erofs *erofs = image->handler_priv;
 	char *extraargs = cfg_getstr(image->imagesec, "extraargs");
+	const char *fs_timestamp = cfg_getstr(image->imagesec, "fs-timestamp");
+	int ret;
 
-	ret = systemp(image, "%s  %s '%s' '%s'",
+	ret = systemp(image, "%s %s%s%s %s%s %s '%s' '%s'",
 		      get_opt("mkfserofs"),
+		      erofs->label ? "-L '" : "",
+		      erofs->label ? erofs->label : "",
+		      erofs->label ? "'" : "",
+		      fs_timestamp ? "-T " : "",
+		      fs_timestamp ? fs_timestamp : "",
 		      extraargs,
 		      imageoutfile(image),
 		      mountpath(image));
@@ -31,13 +47,35 @@ static int erofs_generate(struct image *image)
 	return ret;
 }
 
+static int erofs_setup(struct image *image, cfg_t *cfg)
+{
+	struct erofs *erofs = xzalloc(sizeof(*erofs));
+	const char *label = cfg_getstr(image->imagesec, "label");
+
+	if (label && label[0] == '\0')
+		label = NULL;
+
+	if (label && strlen(label) > 15) {
+		image_error(image, "Label '%s' is longer that allowes (15 bytes)\n", label);
+		return -EINVAL;
+	}
+
+	erofs->label = label;
+
+	image->handler_priv = erofs;
+	return 0;
+}
+
 static cfg_opt_t erofs_opts[] = {
 	CFG_STR("extraargs", "", CFGF_NONE),
+	CFG_STR("label", NULL, CFGF_NONE),
+	CFG_STR("fs-timestamp", NULL, CFGF_NONE),
 	CFG_END()
 };
 
 struct image_handler erofs_handler = {
 	.type = "erofs",
 	.generate = erofs_generate,
+	.setup = erofs_setup,
 	.opts = erofs_opts,
 };

--- a/test/erofs.config
+++ b/test/erofs.config
@@ -1,5 +1,7 @@
 image test.erofs {
 	erofs {
+		fs-timestamp = "20000101000000"
+		extraargs = "-U 83d9e40a-fb96-469e-abb9-24fb3c3bd0ff"
 	}
 	size = 4M
 }

--- a/test/erofs.config
+++ b/test/erofs.config
@@ -1,0 +1,5 @@
+image test.erofs {
+	erofs {
+	}
+	size = 4M
+}

--- a/test/erofs.dump
+++ b/test/erofs.dump
@@ -1,0 +1,91 @@
+Filesystem magic number:                      0xE0F5E1E2
+Filesystem blocks:                            1
+Filesystem inode metadata start block:        0
+Filesystem shared xattr metadata start block: 0
+Filesystem root nid:                          36
+Filesystem inode count:                       41
+Filesystem created:                           Thu Dec 21 11:06:40 635747
+Filesystem features:                          sb_csum mtime 
+Filesystem UUID:                              83d9e40a-fb96-469e-abb9-24fb3c3bd0ff
+Filesystem total file count:		41
+Filesystem unknown type count:		0
+Filesystem regular file count:		24
+Filesystem directory count:		17
+Filesystem char dev count:		0
+Filesystem block dev count:		0
+Filesystem FIFO file count:		0
+Filesystem SOCK file count:		0
+Filesystem symlink file count:		0
+Filesystem compressed files:            0
+Filesystem uncompressed files:          41
+Filesystem total original file size:    0 Bytes
+Filesystem total file size:             0 Bytes
+Filesystem compress rate:               -nan%
+
+Original file size distribution:
+>=(KB) .. <(KB)        count            ratio |distribution                                      |
+     0 .. 1     	24            100.00% |##################################################|
+     1 .. 2     	0               0.00% |                                                  |
+     2 .. 4     	0               0.00% |                                                  |
+     4 .. 8     	0               0.00% |                                                  |
+     8 .. 16    	0               0.00% |                                                  |
+    16 .. 32    	0               0.00% |                                                  |
+    32 .. 64    	0               0.00% |                                                  |
+    64 .. 128   	0               0.00% |                                                  |
+   128 .. 256   	0               0.00% |                                                  |
+   256 .. 512   	0               0.00% |                                                  |
+   512 .. 1024  	0               0.00% |                                                  |
+  1024 .. 2048  	0               0.00% |                                                  |
+  2048 .. 4096  	0               0.00% |                                                  |
+  4096 .. 8192  	0               0.00% |                                                  |
+  8192 .. 16384 	0               0.00% |                                                  |
+ 16384 .. 32768 	0               0.00% |                                                  |
+ 32768 ..       	0               0.00% |                                                  |
+
+On-disk file size distribution:
+>=(KB) .. <(KB)        count            ratio |distribution                                      |
+     0 .. 1     	24            100.00% |##################################################|
+     1 .. 2     	0               0.00% |                                                  |
+     2 .. 4     	0               0.00% |                                                  |
+     4 .. 8     	0               0.00% |                                                  |
+     8 .. 16    	0               0.00% |                                                  |
+    16 .. 32    	0               0.00% |                                                  |
+    32 .. 64    	0               0.00% |                                                  |
+    64 .. 128   	0               0.00% |                                                  |
+   128 .. 256   	0               0.00% |                                                  |
+   256 .. 512   	0               0.00% |                                                  |
+   512 .. 1024  	0               0.00% |                                                  |
+  1024 .. 2048  	0               0.00% |                                                  |
+  2048 .. 4096  	0               0.00% |                                                  |
+  4096 .. 8192  	0               0.00% |                                                  |
+  8192 .. 16384 	0               0.00% |                                                  |
+ 16384 .. 32768 	0               0.00% |                                                  |
+ 32768 ..       	0               0.00% |                                                  |
+
+File type distribution:
+type                   count            ratio |distribution                                      |
+.txt             	0               0.00% |                                                  |
+.so              	0               0.00% |                                                  |
+.xml             	0               0.00% |                                                  |
+.apk             	0               0.00% |                                                  |
+.odex            	0               0.00% |                                                  |
+.vdex            	0               0.00% |                                                  |
+.oat             	0               0.00% |                                                  |
+.rc              	0               0.00% |                                                  |
+.otf             	0               0.00% |                                                  |
+.txt             	0               0.00% |                                                  |
+others           	24            100.00% |##################################################|
+File : /
+Size: 95  On-disk size: 95  directory
+NID: 36   Links: 6   Layout: 2   Compression ratio: 100.00%
+Inode size: 32   Extent size: 0   Xattr size: 0
+Uid: 0   Gid: 0  Access: 0755/rwxr-xr-x
+Timestamp: 635747-12-21 11:06:40.000000000
+
+       NID TYPE  FILENAME
+        36    2  .
+        36    2  ..
+        40    2  bar
+        59    2  baz
+        78    2  foo
+        97    2  with spaces

--- a/test/filesystem.test
+++ b/test/filesystem.test
@@ -77,7 +77,10 @@ exec_test_set_prereq fsck.erofs
 test_expect_success mkfs_erofs,fsck_erofs "erofs" "
 	run_genimage_root erofs.config test.erofs &&
 	fsck.erofs -p images/test.erofs | tee erofs.log &&
-	test_must_fail grep -q 'Filesystem was changed' erofs.log
+	test_must_fail grep -q 'Filesystem was changed' erofs.log &&
+	check_size images/test.erofs 4096 &&
+	dump.erofs -s -S --ls --path=/ images/test.erofs > erofs.dump &&
+	test_cmp ${testdir}/erofs.dump erofs.dump
 "
 
 test_done

--- a/test/filesystem.test
+++ b/test/filesystem.test
@@ -72,6 +72,14 @@ test_expect_success dd,mkdosfs,mcopy "vfat" "
 	check_filelist
 "
 
+exec_test_set_prereq mkfs.erofs
+exec_test_set_prereq fsck.erofs
+test_expect_success mkfs_erofs,fsck_erofs "erofs" "
+	run_genimage_root erofs.config test.erofs &&
+	fsck.erofs -p images/test.erofs | tee erofs.log &&
+	test_must_fail grep -q 'Filesystem was changed' erofs.log
+"
+
 test_done
 
 # vim: syntax=sh


### PR DESCRIPTION
Erofs is a read-only file-system supported by the Linux Kernel since version 5.4.

This patchset adds basic support, a test & documentation for the filesystem.

This replaces #247. It has some minor fixes (erofs.config was missing in `Makefile.am`.
And there are some extra commits for some options and to extend the test.