### PR TITLE
Make mkfs.cramfs the default for cramfs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -289,7 +289,7 @@ Generates cramfs images.
 
 Options:
 
-:extraargs:		Extra arguments passed to mkcramfs
+:extraargs:		Extra arguments passed to mkfs.cramfs
 
 custom
 ******
@@ -776,7 +776,7 @@ variable.
 :genisoimage:	path to the genisoimage program (default genisoimage)
 :mcopy:		path to the mcopy program (default mcopy)
 :mmd:		path to the mmd program (default mmd)
-:mkcramfs:	path to the mkcramfs program (default mkcramfs)
+:mkcramfs:	path to the mkcramfs program (default mkfs.cramfs)
 :mkdosfs:	path to the mkdosfs program (default mkdosfs)
 :mkfserofs:	path to the mkfs.erofs program (default mkfs.erofs)
 :mkfsf2fs:	path to the mkfs.f2fs program (default mkfs.f2fs)

--- a/config.c
+++ b/config.c
@@ -421,7 +421,7 @@ static struct config opts[] = {
 		.name = "mkcramfs",
 		.opt = CFG_STR("mkcramfs", NULL, CFGF_NONE),
 		.env = "GENIMAGE_MKCRAMFS",
-		.def = "mkcramfs",
+		.def = "mkfs.cramfs",
 	},
 	{
 		.name = "mkdosfs",

--- a/test/filesystem.test
+++ b/test/filesystem.test
@@ -15,8 +15,8 @@ test_expect_success cpio "cpio" "
 	check_filelist
 "
 
-exec_test_set_prereq mkcramfs
-test_expect_success mkcramfs "cramfs" "
+exec_test_set_prereq mkfs.cramfs
+test_expect_success mkfs_cramfs "cramfs" "
 	run_genimage_root cramfs.config test.cramfs &&
 	check_size images/test.cramfs 4096
 "


### PR DESCRIPTION
Most recent distros ship util-linux without the compatibility link "mkcramfs" for mkfs.cramfs