### PR TITLE
image-flash: pad the end of the file correctly if it extends past the…

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -91,6 +91,8 @@ EXTRA_DIST += \
 	test/flash-types.config \
 	test/flash.config \
 	test/flash.md5 \
+	test/flash-fill.config \
+	test/flash-fill.md5 \
 	test/gpt-overlap1.config \
 	test/gpt-overlap2.config \
 	test/gpt-overlap3.config \

--- a/image-flash.c
+++ b/image-flash.c
@@ -65,6 +65,14 @@ static int flash_generate(struct image *image)
 		}
 		end = part->offset + part->size;
 	}
+	if (image->size > end) {
+		ret = insert_image(image, NULL, image->size - end, end, 0, 0xFF, cfg_false);
+		if (ret) {
+			image_error(image, "failed to pad image to size %lld\n",
+				    image->size);
+			return ret;
+		}
+	}
 
 	return 0;
 }

--- a/test/flash-fill.config
+++ b/test/flash-fill.config
@@ -1,0 +1,16 @@
+include("flash-types.config")
+
+image test.flash {
+	flash {
+	}
+	flashtype = "nand-64M-512"
+	partition part1 {
+		image = "part1.img"
+		size = 1M
+	}
+	partition part2 {
+		image = "part2.img"
+		size = 1M
+	}
+	size = 3M
+}

--- a/test/flash-fill.md5
+++ b/test/flash-fill.md5
@@ -1,0 +1,1 @@
+00fa74768f013beb47f76edc71e5fc51  images/test.flash

--- a/test/flash.test
+++ b/test/flash.test
@@ -4,9 +4,10 @@ test_description="Flash Image Tests"
 . "$(dirname "${0}")/test-setup.sh"
 
 exec_test_set_prereq dd
-test_expect_success "flash" "
+test_expect_success dd "flash" "
 	setup_test_images &&
 	run_genimage flash.config test.flash &&
+	check_size 'images/test.flash' 2097152 &&
 	md5sum -c '${testdir}/flash.md5'
 "
 

--- a/test/flash.test
+++ b/test/flash.test
@@ -10,6 +10,13 @@ test_expect_success "flash" "
 	md5sum -c '${testdir}/flash.md5'
 "
 
+test_expect_success dd "flash-fill" "
+	setup_test_images &&
+	run_genimage flash-fill.config test.flash &&
+	check_size 'images/test.flash' 3145728 &&
+	md5sum  -c '${testdir}/flash-fill.md5'
+"
+
 exec_test_set_prereq mkfs.jffs2
 test_expect_success mkfs_jffs2 "jffs2" "
 	run_genimage_root jffs2.config test.jffs2 &&


### PR DESCRIPTION
… last partition

Flash images are padded with 0xFF so the default (zero) from creating the file is incorrect here. So if the size of the flash image was explicitly specified and extends beyond the last partition then the rest of the image must be filled with 0xFF.

Fixes: #300