### PR TITLE
btrfs: make sure the image has the expected size

### DIFF
--- a/image-btrfs.c
+++ b/image-btrfs.c
@@ -20,11 +20,13 @@
 #include <string.h>
 #include <stdlib.h>
 #include <errno.h>
+#include <sys/stat.h>
 
 #include "genimage.h"
 
 static int btrfs_generate(struct image *image)
 {
+	struct stat s;
 	int ret;
 
 	const char *label = cfg_getstr(image->imagesec, "label");
@@ -48,6 +50,19 @@ static int btrfs_generate(struct image *image)
 
 	if (ret || image->empty)
 		return ret;
+
+	ret = stat(imageoutfile(image), &s);
+	if (ret) {
+		image_error(image, "stat(%s) failed: %s\n", imageoutfile(image), strerror(errno));
+		return ret;
+	}
+	if (image->size && image->size != (unsigned long long)s.st_size) {
+		image_error(image, "Created image to big: %llu > %llu\n",
+			    (unsigned long long)s.st_size, image->size);
+		return -E2BIG;
+	}
+	if (!image->size)
+		image->size = s.st_size;
 
 	return ret;
 }

--- a/test/btrfs.config
+++ b/test/btrfs.config
@@ -4,5 +4,5 @@ image test.btrfs {
 		# set UUID to test if extraargs works
 		extraargs = "--uuid 47e790af-a2e1-42ff-92c7-83f45f7b2228"
 	}
-	size = 64M
+	size = 128M
 }

--- a/test/filesystem.test
+++ b/test/filesystem.test
@@ -38,10 +38,10 @@ test_expect_success mkfs_f2fs,sload_f2fs,fsck_f2fs "f2fs" "
 exec_test_set_prereq btrfs
 exec_test_set_prereq mkfs.btrfs
 test_expect_success mkfs_btrfs,btrfs "btrfs" "
-	run_genimage_root btrfs.config test.btrfs
-	btrfs check images/test.btrfs
-	test \"\$(btrfs filesystem label images/test.btrfs)\" = btrfstest
-	btrfs filesystem show images/test.btrfs | grep \"uuid: 47e790af-a2e1-42ff-92c7-83f45f7b2228\"
+	run_genimage_root btrfs.config test.btrfs &&
+	btrfs check images/test.btrfs &&
+	test \"\$(btrfs filesystem label images/test.btrfs)\" = btrfstest &&
+	btrfs filesystem show images/test.btrfs | grep -q \"uuid: 47e790af-a2e1-42ff-92c7-83f45f7b2228\"
 "
 
 exec_test_set_prereq mksquashfs


### PR DESCRIPTION
At least in some cases, mkfs.btrfs will increase the image size if the file is too small. So add a sanity check to ensure the the image has the expected size.

Fixes: #287