### PR TITLE
readme: Update ubifs mkfs tool name

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -633,7 +633,7 @@ read from.
 
 Options:
 
-:extraargs:		Extra arguments passed to mkubifs
+:extraargs:		Extra arguments passed to mkfs.ubifs
 :max-size:		Maximum size of the UBIFS image
 :space-fixup:           Instructs the file-system free space to be freed up on first mount.
 


### PR DESCRIPTION
Could not find any tool named mkubifs.  Change to the default tool which is actually called.