### PR TITLE
Add macOS/BSD support

### DIFF
--- a/config.c
+++ b/config.c
@@ -21,6 +21,7 @@
 #include <errno.h>
 #include <getopt.h>
 #include <unistd.h>
+#include <limits.h>
 
 #include "genimage.h"
 
@@ -279,7 +280,18 @@ static char *abspath(const char *path)
 	if (*path == '/')
 		return strdup(path);
 
+#ifdef __GLIBC__
+	/* Use GNU extension on Linux */
 	xasprintf(&p, "%s/%s", get_current_dir_name(), path);
+#else
+	/* Use POSIX standard for macOS/BSD */
+	char cwd[PATH_MAX];
+	if (getcwd(cwd, sizeof(cwd)) == NULL) {
+		fprintf(stderr, "getcwd failed: %s\n", strerror(errno));
+		return NULL;
+	}
+	xasprintf(&p, "%s/%s", cwd, path);
+#endif
 
 	return p;
 }

--- a/genimage.h
+++ b/genimage.h
@@ -5,6 +5,10 @@
 #include <confuse.h>
 #include "list.h"
 
+#ifndef __GLIBC__
+#define strdupa(s) strdup(s)
+#endif
+
 struct image_handler;
 
 struct image *image_get(const char *filename);

--- a/image-android-sparse.c
+++ b/image-android-sparse.c
@@ -15,7 +15,15 @@
  */
 
 #include <confuse.h>
+#ifdef __APPLE__
+#include <libkern/OSByteOrder.h>
+#define htole16(x) OSSwapHostToLittleInt16(x)
+#define htole32(x) OSSwapHostToLittleInt32(x)
+#define le16toh(x) OSSwapLittleToHostInt16(x)
+#define le32toh(x) OSSwapLittleToHostInt32(x)
+#else
 #include <endian.h>
+#endif
 #include <errno.h>
 #include <fcntl.h>
 #include <stdlib.h>

--- a/image-hd.c
+++ b/image-hd.c
@@ -22,7 +22,17 @@
 #include <stdlib.h>
 #include <errno.h>
 #include <inttypes.h>
+#ifdef __APPLE__
+#include <libkern/OSByteOrder.h>
+#define htole16(x) OSSwapHostToLittleInt16(x)
+#define htole32(x) OSSwapHostToLittleInt32(x)
+#define htole64(x) OSSwapHostToLittleInt64(x)
+#define le16toh(x) OSSwapLittleToHostInt16(x)
+#define le32toh(x) OSSwapLittleToHostInt32(x)
+#define le64toh(x) OSSwapLittleToHostInt64(x)
+#else
 #include <endian.h>
+#endif
 #include <stdbool.h>
 #include <unistd.h>
 #include <sys/types.h>

--- a/image-mdraid.c
+++ b/image-mdraid.c
@@ -34,9 +34,14 @@
 #include <string.h>
 #include <time.h>
 #include <errno.h>
+
+#ifdef __linux__
 #include <linux/raid/md_p.h>
+#endif
 
 #include "genimage.h"
+
+#ifdef __linux__
 
 #define DATA_OFFSET_SECTORS (2048)
 #define DATA_OFFSET_BYTES   (DATA_OFFSET_SECTORS * 512)
@@ -486,3 +491,48 @@ struct image_handler mdraid_handler = {
 	.generate = mdraid_generate,
 	.opts = mdraid_opts,
 };
+
+#else /* !__linux__ */
+
+/* Stub implementation for non-Linux systems */
+static int mdraid_parse(struct image *image, cfg_t *cfg)
+{
+	image_error(image, "MDRAID is only supported on Linux\n");
+	return -1;
+}
+
+static int mdraid_generate(struct image *image)
+{
+	image_error(image, "MDRAID is only supported on Linux\n");
+	return -1;
+}
+
+static int mdraid_setup(struct image *image, cfg_t *cfg)
+{
+	image_error(image, "MDRAID is only supported on Linux\n");
+	return -1;
+}
+
+static cfg_opt_t mdraid_opts[] = {
+	CFG_STR("label", "any:42", CFGF_NONE),
+	CFG_INT("level", 1, CFGF_NONE),
+	CFG_INT("devices", 1, CFGF_NONE),
+	CFG_INT("role", -1, CFGF_NONE),
+	CFG_INT("timestamp", -1, CFGF_NONE),
+	CFG_STR("raid-uuid", NULL, CFGF_NONE),
+	CFG_STR("disk-uuid", NULL, CFGF_NONE),
+	CFG_STR("image", NULL, CFGF_NONE),
+	CFG_STR("parent", NULL, CFGF_NONE),
+	CFG_END()
+};
+
+struct image_handler mdraid_handler = {
+	.type = "mdraid",
+	.no_rootpath = cfg_true,
+	.parse = mdraid_parse,
+	.setup = mdraid_setup,
+	.generate = mdraid_generate,
+	.opts = mdraid_opts,
+};
+
+#endif /* __linux__ */

--- a/image-verity.c
+++ b/image-verity.c
@@ -22,7 +22,9 @@
 #include <string.h>
 #include <stdlib.h>
 #include <unistd.h>
+#ifdef __linux__
 #include <sys/sendfile.h>
+#endif
 #include <sys/stat.h>
 
 #include "genimage.h"
@@ -337,13 +339,23 @@ static int verity_generate(struct image *image)
 		return -errno;
 
 	if (image->size && image->size < (unsigned long)sb.st_size) {
+#ifdef __APPLE__
+		image_error(image,
+			    "Specified image size (%llu) is too small, generated %lld bytes\n",
+			    image->size, sb.st_size);
+#else
 		image_error(image,
 			    "Specified image size (%llu) is too small, generated %ld bytes\n",
 			    image->size, sb.st_size);
+#endif
 		return -E2BIG;
 	}
 
+#ifdef __APPLE__
+	image_debug(image, "generated %lld bytes\n", sb.st_size);
+#else
 	image_debug(image, "generated %ld bytes\n", sb.st_size);
+#endif
 	image->size = sb.st_size;
 	return 0;
 }


### PR DESCRIPTION
- Fix endian.h compatibility on macOS
- Replace GNU extensions (get_current_dir_name, sscanf %m, strdupa)
- Add mdraid stub for non-Linux systems
- Correct format specifiers for off_t type on macOS

Tested on macOS 26.0 with Apple clang 17.0.0 and FreeBSD 14.3 with FreeBSD clang 19.1.7.