### PR TITLE
util: systemp: set pipefail flag

### DIFF
--- a/test/filesystem.test
+++ b/test/filesystem.test
@@ -15,6 +15,10 @@ test_expect_success cpio "cpio" "
 	check_filelist
 "
 
+test_expect_failure "cpio missing" "
+	GENIMAGE_CPIO=/usr/bin/cpio-not-available run_genimage_root cpio.config test.cpio
+"
+
 exec_test_set_prereq mkfs.cramfs
 test_expect_success mkfs_cramfs "cramfs" "
 	run_genimage_root cramfs.config test.cramfs &&

--- a/util.c
+++ b/util.c
@@ -271,7 +271,7 @@ int systemp(struct image *image, const char *fmt, ...)
 		if (!shell || shell[0] == 0x0)
 			shell = "/bin/sh";
 
-		execl(shell, shell, "-c", buf, NULL);
+		execl(shell, shell, "-o", "pipefail", "-c", buf, NULL);
 		ret = -errno;
 		error("Cannot execute %s: %s\n", buf, strerror(errno));
 		goto err_out;


### PR DESCRIPTION
This draft PR implements the change suggested in #320. It is a draftbecause the tests currently fail for at least Ubuntu 22.04 with the message: `/bin/sh: 0: Illegal option -o pipefail`.

---

This ensures that the whole call to `systemp` fails if one commands in a command line consisting of multiple commands joined by pipes fails.

This is for example relevant for the `cpio` backend, where the `cpio` command is called and its output is piped to `gzip`.
If the `cpio` command fails or is not found at all a `.cpio.gz` file will be created containing just the gzip header and genimage will return a successful exit status anyways.

This change assumes that all relevant `/bin/sh` implementations support the `-o pipefail` option. We know that at least bash, dash and busybox ash do.

Fixes #320.