### PR TITLE
image-hd: populate hd file size right after creating GPT header

### DIFF
--- a/image-hd.c
+++ b/image-hd.c
@@ -1063,6 +1063,7 @@ static int hdimage_setup(struct image *image, cfg_t *cfg)
 			gpt_backup = fake_partition("[GPT backup]", backup_offset, backup_size);
 			list_add_tail(&gpt_backup->list, &image->partitions);
 		}
+		hd->file_size = now;
 	}
 
 	list_for_each_entry(part, &image->partitions, list) {


### PR DESCRIPTION
The current code cannot handle config file like this (this is when I only want to create a GPT partition table without any content):

```
image partition.img {
	hdimage {
		partition-table-type = "gpt"
		gpt-no-backup = true
	}

	partition uboot {
		offset = 4M
		size = 2M
	}
}
```

Error log: `ERROR: hdimage(partition.img): unexpected output file size: 0 != 17408`

Reason: When gpt-no-backup = true and no partition has an image file, hd->file_size was never set from its initial value of 0. This makes it impossible to create an image with only GPT header.

Fix: Initialize hd->file_size to now (= partition_end(gpt_array) = 17408) right after the primary GPT structures are set up. This ensures the file will always be at least large enough to hold the primary GPT header and partition array.