### PR TITLE
util: systemp: set pipefail flag

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -151,6 +151,7 @@ EXTRA_DIST += \
 	test/mke2fs.1.dump \
 	test/mke2fs.2.dump \
 	test/mke2fs.3.dump \
+	test/pipefail.config \
 	test/qemu.config \
 	test/qemu.qcow.gz \
 	test/randomseed.config \

--- a/configure.ac
+++ b/configure.ac
@@ -73,6 +73,28 @@ AS_IF([test "x${enable_debug}" = "xyes"],
 	enable_hide=no],
 	[AC_MSG_RESULT([${enable_hide}])])
 
+AC_ARG_WITH([shell],
+	[AS_HELP_STRING([--with-shell],
+		[default shell to execute commands @<:@default=/bin/sh@:>@])],
+	[],
+	[
+		if test "$cross_compiling" = yes; then
+			AC_MSG_ERROR([--with-shell=... must be used to specify a shell that supports `-o pipefail` when cross compiling])
+		else
+			for shell in /bin/sh /bin/bash; do
+				if "${shell}" -o pipefail -c true > /dev/null 2>&1; then
+					with_shell="${shell}"
+					break
+				fi
+			done
+			if test "x${with_shell}" = "x"; then
+				AC_MSG_ERROR([No working shell found use --with-shell=... to specify a shell that supports `-o pipefail`])
+			fi
+		fi
+	 ])
+
+AC_DEFINE_UNQUOTED([GENIMAGE_SHELL], ["${with_shell}"],[Default shell])
+
 # ----------- autodetect some settings -------------------
 
 # add as much warnings and features as possible, but check what the compiler
@@ -147,4 +169,5 @@ AC_MSG_RESULT([
         debug:                  ${enable_debug}
         hide symbols:           ${enable_hide}
         libconfuse:             ${CONFUSE_LIBS}
+	default shell:          ${with_shell}
 ])

--- a/test/filesystem.test
+++ b/test/filesystem.test
@@ -15,6 +15,10 @@ test_expect_success cpio "cpio" "
 	check_filelist
 "
 
+test_expect_failure "cpio missing" "
+	GENIMAGE_CPIO=/usr/bin/cpio-not-available run_genimage_root cpio.config test.cpio
+"
+
 exec_test_set_prereq mkfs.cramfs
 test_expect_success mkfs_cramfs "cramfs" "
 	run_genimage_root cramfs.config test.cramfs &&

--- a/test/misc.test
+++ b/test/misc.test
@@ -143,6 +143,11 @@ test_expect_success "custom" "
 	echo 'Hello genimage!' > images/test.custom.expect &&
 	test_cmp images/test.custom.expect images/test.custom
 "
+
+test_expect_success "pipefail" "
+	test_must_fail run_genimage pipefail.config
+"
+
 test_expect_success "disable random-seed" "
 	extra_opts="--randomseed=" &&
 	run_genimage randomseed.config randomseed.img &&

--- a/test/pipefail.config
+++ b/test/pipefail.config
@@ -1,0 +1,5 @@
+image test.custom {
+	custom {
+		exec = 'false | true'
+	}
+}

--- a/util.c
+++ b/util.c
@@ -271,7 +271,7 @@ int systemp(struct image *image, const char *fmt, ...)
 		if (!shell || shell[0] == 0x0)
 			shell = "/bin/sh";
 
-		execl(shell, shell, "-c", buf, NULL);
+		execl(shell, shell, "-o", "pipefail", "-c", buf, NULL);
 		ret = -errno;
 		error("Cannot execute %s: %s\n", buf, strerror(errno));
 		goto err_out;

--- a/util.c
+++ b/util.c
@@ -269,7 +269,7 @@ int systemp(struct image *image, const char *fmt, ...)
 
 		shell = getenv("GENIMAGE_SHELL");
 		if (!shell || shell[0] == 0x0)
-			shell = "/bin/sh";
+			shell = GENIMAGE_SHELL;
 
 		execl(shell, shell, "-o", "pipefail", "-c", buf, NULL);
 		ret = -errno;


### PR DESCRIPTION
This ensures that the whole call to systemp fails if one commands in a command line consisting of multiple commands joined by pipes fails.

This is for example relevant for the cpio backend, where the cpio command is called and its output is piped to gzip.
If the cpio command fails or is not found at all a .cpio.gz file will be created containing just the gzip header and genimage will return a successful exit status anyways.

`/bin/sh` does not always support `-o pipefail`, so this adds a configure option and check to provide a default shell that works.